### PR TITLE
io: opaque ring_context + drop liburing from public headers

### DIFF
--- a/docs/io-backend-port-plan.md
+++ b/docs/io-backend-port-plan.md
@@ -1,0 +1,400 @@
+<!--
+SPDX-FileCopyrightText: 2026 Tom Haynes <loghyr@gmail.com>
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# I/O Backend Port Plan — FreeBSD + macOS
+
+**Date:** 2026-04-18
+**Goal:** Abstract reffs' I/O layer behind a narrow backend interface so it
+runs natively on Linux (liburing, unchanged), FreeBSD (aio + kqueue),
+and macOS (thread pool). Shake out io_uring-specific bugs via
+triangulation across three backends with different completion
+semantics.
+
+---
+
+## Motivation
+
+1. **Cross-platform reach.** Run reffs on witchie (FreeBSD 15) and mana
+   (macOS) in addition to shadow/adept (Linux). Useful for NFS protocol
+   testing against a second server stack and for local dev on the
+   MacBook.
+2. **Bug triangulation.** A second (and third) I/O implementation with
+   different completion semantics is a better regression test than any
+   amount of Linux-only unit coverage. Bugs that repro on all backends
+   are app-level; bugs on one backend are backend-specific.
+3. **Header hygiene.** Today `<liburing.h>` leaks into four public
+   headers (`io.h`, `ring.h`, `task.h`, `rpc.h`). Even if the port is
+   never shipped, the abstraction work has standalone value.
+
+---
+
+## Current State Analysis
+
+### What's already good
+
+- `lib/io/` is a dedicated layer with a clean op-level API in
+  `lib/include/reffs/io.h`. Callers (NFS op handlers) hit high-level
+  `io_request_*` functions, not raw liburing.
+- Protocol is completion-oriented: ops submit, task pauses,
+  completion resumes the task. Same shape as FreeBSD aio+kqueue and as
+  a thread-pool with condvar.
+- **Op surface is narrow.** The only `io_uring_prep_*` calls in the
+  codebase are: `accept`, `connect`, `read`, `write`, `poll_add`,
+  `timeout`, `cancel`. Seven ops. All have direct FreeBSD / macOS
+  equivalents.
+- **No unportable features in use.** No `IOSQE_IO_LINK` chains, no
+  `IORING_REGISTER_BUFFERS` / registered fds, no
+  `IORING_OP_OPENAT`, no `IORING_SETUP_SQPOLL`, no zero-copy
+  (`sendzc`). Only two feature-gates: `IORING_FEAT_NODROP` and
+  `IORING_FEAT_EXT_ARG`, both perf/ergonomic not semantic.
+- `tsan_uring.h` (32 lines) is pure `__tsan_release` / `__tsan_acquire`
+  barriers. Implementation is io_uring-agnostic; only the filename
+  references io_uring. Trivial rename to `tsan_io.h`.
+
+### What leaks
+
+- `#include <liburing.h>` appears in `lib/include/reffs/io.h`,
+  `ring.h`, `task.h`, and `rpc.h`. Every module that includes any of
+  those transitively pulls in liburing.
+- `struct ring_context` (in `ring.h`) has a
+  `struct io_uring rc_ring` field directly. Hard ABI leak.
+- Two separate rings at runtime: `io_handler_main_loop` (network) and
+  `io_backend_main_loop` (file I/O). Both need to be ported, not just
+  one.
+- `handler.c:174` runtime-checks `IORING_FEAT_NODROP`;
+  `handler.c:422` runtime-checks `IORING_FEAT_EXT_ARG`. Both need
+  `#ifdef` or a backend-method equivalent.
+
+---
+
+## Goals
+
+1. Three I/O backends, compile-time selected:
+   - `backend_liburing.c` — Linux, current behavior, zero performance
+     regression.
+   - `backend_kqueue.c` — FreeBSD, POSIX `aio(4)` + `kqueue(2)` with
+     `EVFILT_AIO` completions.
+   - `backend_threadpool.c` — macOS primarily, also a portable fallback
+     on any POSIX. Worker threads doing blocking `pread`/`pwrite`,
+     completions via internal condvar/eventfd-equivalent.
+2. `<liburing.h>` not present in any public header. Types in headers
+   are either POSIX or reffs-native.
+3. `struct ring_context` is opaque in headers; full definition lives
+   in the active backend's `.c` file (or a shared private header).
+4. All existing Linux tests pass unchanged (the liburing backend keeps
+   semantic parity).
+5. A new backend-level smoke test runs on all three backends from one
+   harness.
+
+## Non-goals
+
+- Not replacing liburing with libuv/libev/libevent. They're either too
+  readiness-oriented (libev/libevent) or force a larger refactor
+  (libuv) without the cross-backend-triangulation benefit we want.
+- Not porting to Windows. No one asked for it.
+- Not supporting pre-FreeBSD 13 (which lacks `accept4(2)`).
+- Not supporting pre-macOS 11 on the thread-pool backend (no specific
+  blocker found yet; revisit if needed).
+- **Not exposing io_uring-only features in the backend API.**
+  Registered buffers, IOSQE_IO_LINK, etc. are explicitly out of scope.
+  If future reffs features need them, that's a new plan.
+
+---
+
+## Architecture
+
+### Backend interface
+
+Defined in `lib/include/reffs/io_backend.h` (new). Opaque handles,
+POSIX types, backend-neutral op semantics. Something like:
+
+```c
+struct io_backend;             /* opaque */
+struct io_op;                  /* opaque; owned by caller, embedded
+                                  in io_context today */
+
+int  io_backend_init(struct io_backend **out, size_t sq_size,
+                     size_t cq_size);
+void io_backend_fini(struct io_backend *be);
+
+int  io_submit_read (struct io_backend *, struct io_op *,
+                     int fd, void *buf, size_t len, off_t offset);
+int  io_submit_write(struct io_backend *, struct io_op *,
+                     int fd, const void *buf, size_t len, off_t offset);
+int  io_submit_accept (struct io_backend *, struct io_op *, int fd);
+int  io_submit_connect(struct io_backend *, struct io_op *,
+                       int fd, const struct sockaddr *, socklen_t);
+int  io_submit_poll   (struct io_backend *, struct io_op *,
+                       int fd, short events);
+int  io_submit_timeout(struct io_backend *, struct io_op *,
+                       const struct timespec *);
+int  io_submit_cancel (struct io_backend *, struct io_op *target);
+
+int  io_backend_submit(struct io_backend *);  /* kick submissions */
+int  io_backend_reap(struct io_backend *,
+                     const struct timespec *timeout,
+                     struct io_op **completed, int *result,
+                     int max);                /* drain completions */
+```
+
+Each backend implements the same interface, selected at compile time:
+
+```c
+#if defined(__linux__)
+  #include "backend_liburing.c"  /* or linked as .o */
+#elif defined(__FreeBSD__)
+  #include "backend_kqueue.c"
+#elif defined(__APPLE__)
+  #include "backend_threadpool.c"
+#else
+  #error "unsupported platform"
+#endif
+```
+
+Builds pick exactly one via Makefile.am conditional compilation.
+
+### Two rings → two backends
+
+reffs runs two rings today (network + backend-file-I/O) for latency
+isolation. The pattern carries over: `io_backend_init()` is called
+twice (once per main loop), each gets its own backend instance,
+each has its own main loop draining completions. On FreeBSD that's
+two kqueue fds. On threadpool, two worker pools (or one pool with two
+completion queues). No shared-backend-state simplification.
+
+### TSAN annotations
+
+`lib/io/tsan_uring.h` → rename `lib/io/tsan_io.h`. Content unchanged
+(macros are io_uring-agnostic). Every backend calls `TSAN_RELEASE`
+before handing an op to the kernel (or to a worker thread) and
+`TSAN_ACQUIRE` on the completion side.
+
+---
+
+## Phased PR Sequence
+
+### PR 1 — Header hygiene + backend interface definition
+
+**Goal:** No behavior change. The existing liburing implementation
+survives, just moves behind the new interface. Tests pass unchanged.
+
+- Define `lib/include/reffs/io_backend.h` with the opaque interface
+  above.
+- Make `struct ring_context` opaque in `lib/include/reffs/ring.h`;
+  move the full definition (including `struct io_uring rc_ring`) to a
+  new private header `lib/io/ring_internal.h` or inline into
+  `backend_liburing.c`.
+- Drop `#include <liburing.h>` from `io.h`, `ring.h`, `task.h`,
+  `rpc.h`. Any remaining uses of io_uring types in those headers
+  (audit with `grep -E "io_uring_(sqe|cqe)" lib/include/reffs/`) move
+  to private headers or become opaque via the new interface.
+- Rename `tsan_uring.h` → `tsan_io.h`, update includes.
+- Rename functions/types where "ring" terminology is misleading (see
+  W-6 below) — **OR** leave names as historical artifacts and document.
+  Default: leave names, add comment in `io_backend.h`.
+- Refactor `lib/io/backend.c`, `handler.c`, `read.c`, `write.c`,
+  `accept.c`, `connect.c`, `worker.c` to call through the new
+  `io_backend.h` interface. Internals unchanged — still liburing.
+- Add stub `lib/io/backend_kqueue.c.in` and
+  `backend_threadpool.c.in`: function prototypes matching the
+  interface, `#error "not implemented"` bodies. Not compiled. Purely
+  to prove the interface is drawable and to make PR 2/3 reviewers'
+  jobs easier.
+- `make check` passes on shadow; no binary or behavior diff vs. main.
+
+**Effort:** 1–2 days focused.
+
+### PR 2 — FreeBSD `aio(4)` + `kqueue(2)` backend
+
+**Goal:** Runs on witchie. Linux unchanged.
+
+- Implement `backend_kqueue.c`: one kqueue per backend instance,
+  `aio_read` / `aio_write` / `aio_fsync` issue + `EVFILT_AIO`
+  completion; `kevent` `EVFILT_READ`/`EVFILT_WRITE` for
+  accept/connect/poll; `EVFILT_TIMER` for timeout; `aio_cancel` +
+  `EV_DELETE` for cancel.
+- Autotools detection: `AC_CHECK_HEADERS([sys/event.h sys/aio.h])`
+  and `AC_CHECK_FUNCS([aio_read aio_write aio_cancel kqueue kevent])`.
+- `#ifdef __FreeBSD__` the `IORING_FEAT_NODROP` and
+  `IORING_FEAT_EXT_ARG` gates in `handler.c` (which is now
+  `backend_liburing.c` internal).
+- Raise `kern.maxaio*` at startup if below expected outstanding-op
+  count (via `sysctl` — log warning if we can't).
+- Port `io_backend_main_loop` to a kqueue-driven loop. Port
+  `io_handler_main_loop` likewise.
+- Add FreeBSD to CI (a witchie-side smoke run).
+
+**Effort:** 2–3 days focused.
+
+### PR 3 — Thread-pool backend (macOS + portable fallback)
+
+**Goal:** Runs on mana. Also a second no-io_uring data point on
+Linux/FreeBSD for bug triangulation.
+
+- Implement `backend_threadpool.c`: fixed pool of worker threads
+  (size tunable, default `nproc` or `sysconf(_SC_NPROCESSORS_ONLN)`);
+  per-backend submission queue (mutex + condvar); completion queue
+  returned via `io_backend_reap`; blocking `pread` / `pwrite` /
+  `accept` / `connect` / `poll` (via `poll(2)` with short timeout)
+  inside worker threads.
+- Cancel semantics: set a cancelled flag on the op; best-effort — in
+  flight ops complete normally with a cancelled result if still
+  pending, otherwise complete as usual.
+- Compile-time selection on `__APPLE__`. Also selectable via a
+  `--with-io-backend=threadpool` configure flag for forcing it on
+  Linux/FreeBSD during triangulation runs.
+- Add macOS to CI (mana-side smoke run if feasible; otherwise docs-
+  only "works on macOS").
+
+**Effort:** 1 day focused.
+
+### PR 4 — Smoke test harness
+
+**Goal:** Catches backend bugs before the reffs-integration tests.
+
+- New test in `lib/io/tests/` that runs a known op pattern (e.g.,
+  1 k × 4 KB `pread` + 1 k × 4 KB `pwrite` + 64 × fsync) through the
+  backend interface and verifies correctness. Not a perf bench — just
+  correctness. Runs against whichever backend is compiled in. In
+  `make check`.
+- Optional follow-up: run the same harness with `--with-io-backend=`
+  forced to each backend on Linux, as a CI matrix job. Divergence =
+  backend bug.
+
+**Effort:** 0.5 day.
+
+---
+
+## Reviewer Findings (c-protocol-review-prompts)
+
+### BLOCKER
+None.
+
+### WARNING
+
+- **W-1. Two main loops.** `io_handler_main_loop` (network) and
+  `io_backend_main_loop` (file I/O) are structurally distinct. Port
+  both, not just one. Each backend instance is independent.
+- **W-2. `IORING_FEAT_NODROP` gate in `handler.c:174`.** CQE overflow
+  handling. kqueue has no equivalent gating (events either enqueue or
+  return `EV_OVERFLOW` explicitly). `#ifdef __linux__` the branch, or
+  add a `be->supports_no_drop` backend method.
+- **W-3. `IORING_FEAT_EXT_ARG` gate in `handler.c:422`.** Per-submit
+  timeout. `kevent()` takes `struct timespec *timeout` natively.
+  `#ifdef` or backend-method "submit_with_timeout".
+- **W-4. Header leakage scope audit.** Before PR 1, run
+  `grep -E "io_uring_(sqe|cqe)" lib/include/reffs/` to enumerate
+  every io_uring type reference in public headers. If hits are
+  confined to `struct ring_context`'s field, PR 1 is small. If there
+  are user-facing structs with `struct io_uring_cqe *cqe` fields, PR 1
+  is wider.
+- **W-5. FreeBSD aio kernel tunables.** `kern.maxaiops`,
+  `kern.maxaio`, `kern.aio_max_aio_per_proc`. Defaults differ by
+  FreeBSD version (low on < 14, 1024 on 14+). Probe at startup; log a
+  warning if limits are below expected outstanding-op count. Consider
+  raising via `sysctl` at startup if running as root.
+- **W-6. Ring terminology in public API.** `io_backend_set_global()` /
+  `io_backend_get_global()` return `struct ring_context *`. On
+  FreeBSD/macOS there is no ring. Options: (a) rename to
+  `io_context` — mechanical churn across all callers; (b) leave as
+  historical artifact with a comment. **Decision:** leave, document.
+
+### NOTE
+
+- **N-1. macOS aio is not worth pursuing.** Older macOS doesn't
+  deliver aio completions via kqueue at all (signal-only); newer
+  versions have `EVFILT_MACHPORT` workarounds but libdispatch (GCD)
+  is the "native" completion model. The thread-pool backend is both
+  simpler and more portable than any macOS-specific aio path.
+- **N-2. Three backends >> two for bug triangulation.** Bug on all
+  three = app logic. Bug on one = backend bug. Bug on two that
+  exclude liburing = portable bug that io_uring happens to hide.
+  Strong argument for PR 3 even if macOS support weren't a goal.
+- **N-3. Smoke test harness (PR 4) is high leverage.** 200 LOC,
+  catches backend bugs without running the full reffs stack. Include
+  even if the rest of the plan slips.
+- **N-4. `IORING_FEAT_NODROP` assumption already requires kernel
+  5.11+.** If this has never bitten us, all production kernels are
+  5.11+. Worth a CHANGELOG note when PR 2 lands clarifying kernel
+  requirements for the Linux backend.
+- **N-5. macOS `accept4` equivalent.** macOS lacks `accept4(2)`. Use
+  `accept(2)` + `fcntl(F_SETFL, O_NONBLOCK)` + `fcntl(F_SETFD,
+  FD_CLOEXEC)` in `backend_threadpool.c`'s accept handler. Two extra
+  syscalls, not a correctness issue.
+
+### PLAN-WARNING
+
+PR 1 reviewers cannot tell whether the opaque types are drawn at the
+right boundary unless they see at least an outline of PR 2. Include
+stub `backend_kqueue.c.in` / `backend_threadpool.c.in` files with
+function prototypes and `#error "not implemented"` bodies in PR 1.
+Proves the boundary is right without shipping working backends.
+
+---
+
+## Revised Effort Summary
+
+| Phase | Effort |
+|-------|--------|
+| PR 1: header hygiene + opaque interface | 1–2 days |
+| PR 2: FreeBSD kqueue backend | 2–3 days |
+| PR 3: thread-pool backend (macOS) | 1 day |
+| PR 4: backend smoke test harness | 0.5 day |
+| **Total** | **4.5–6.5 days** |
+
+---
+
+## Open Questions / Decisions to Make Before Coding
+
+1. **Where do FreeBSD aio limits get raised?** Runtime `sysctl` at
+   startup if root, or document as operator responsibility?
+   *Proposed:* log current limits, warn if below expected outstanding,
+   don't silently raise.
+2. **Thread-pool worker count**: default to `nproc`, or expose as
+   `[iouring] workers = N` config (which would need renaming since
+   "iouring" is misleading)?
+   *Proposed:* add new `[io_backend] workers = N`, fall back to
+   `[iouring]` as deprecated alias for one release.
+3. **Rename the `[iouring]` TOML section?** It configures ring sizes
+   which only apply to the liburing backend; the field names
+   (`network_sq_size` etc.) are io_uring-specific.
+   *Proposed:* rename to `[io_backend]`, keep `[iouring]` as
+   deprecated-alias for one release, generic field names
+   (`submit_queue_depth`, `completion_queue_depth`).
+4. **CI matrix**: run which backends on which CI host?
+   *Proposed:* shadow runs `backend_liburing` (current); witchie runs
+   `backend_kqueue`; add `--with-io-backend=threadpool` nightly on
+   shadow as a triangulation signal.
+
+---
+
+## Relevant Code Pointers
+
+- Public headers with liburing leaks:
+  `lib/include/reffs/io.h`,
+  `lib/include/reffs/ring.h`,
+  `lib/include/reffs/task.h`,
+  `lib/include/reffs/rpc.h`
+- Current I/O implementation: `lib/io/*.c` (accept, backend, connect,
+  context, handler, heartbeat, lsnr, read, tls, worker, write)
+- TSAN shim: `lib/io/tsan_uring.h`
+- Two runtime feature gates: `lib/io/handler.c:174` and `:422`
+- Ops actually used (search reproducibility):
+  `grep -roE "io_uring_prep_[a-z_]+" lib/ src/ | awk -F: '{print $2}' | sort -u`
+  → `accept connect cancel poll_add read timeout write`
+
+---
+
+## How to Resume After an Outage
+
+1. Re-read this document, §Current State Analysis and §Architecture.
+2. Run the audit grep commands at end of §Relevant Code Pointers and
+   check that `grep -c "io_uring_prep_" lib/ src/ -r` hasn't grown
+   (indicating new ops added since the plan was written).
+3. Start with PR 1 (header hygiene). It's standalone; no FreeBSD
+   knowledge needed. Reviewers can approve it on Linux-only merits.
+4. PR 2 (FreeBSD) and PR 3 (thread-pool) are independent of each
+   other after PR 1 lands. Whichever is easier to write first is fine.
+5. PR 4 (smoke test) can land anytime after PR 1.

--- a/docs/io-backend-port-plan.md
+++ b/docs/io-backend-port-plan.md
@@ -398,3 +398,94 @@ Proves the boundary is right without shipping working backends.
 4. PR 2 (FreeBSD) and PR 3 (thread-pool) are independent of each
    other after PR 1 lands. Whichever is easier to write first is fine.
 5. PR 4 (smoke test) can land anytime after PR 1.
+
+---
+
+## Status Update — 2026-04-19
+
+**What's landed on branch**
+
+- `feature/io-backend-port` (PR 1, 4 commits): public headers no longer
+  pull `<liburing.h>`; `struct ring_context` is opaque with
+  `ring_context_alloc()` / `_free()` helpers; `tsan_uring.h` → `tsan_io.h`.
+  Tests 114/114 pass on Linux.
+
+- `feature/freebsd-substrate` (17 commits): `./configure && make`
+  completes on FreeBSD 15.  Covers libtirpc optional, fuse3 path,
+  `-include rpc/rpc.h` for XDR, `-DEREMOTEIO=EIO` / `-DENODATA=ENOATTR`
+  shims, `-Wno-gnu` for liburcu, rocksdb pkg-config rpath strip,
+  portable `reffs_gettid()`, HdrHistogram_c gating, `<sys/sysmacros.h>`
+  gate, Linux FICLONERANGE gate, `loff_t` typedef, GSS-RPC gated on
+  `HAVE_RPC_AUTH_GSS_H`, `-lexecinfo` for backtrace(3), `fuse.c` /
+  `mds_session.c` compat handling.
+
+- `feature/io-backend-kqueue` (PR 2, 8 commits): complete kqueue
+  backend in `lib/io/backend_kqueue.c` (994 lines).  Implements:
+  file I/O via aio_read/write + EVFILT_AIO; accept via EVFILT_READ +
+  accept4; nonblocking connect + EVFILT_WRITE; read/write via
+  synchronous on EVFILT_READ/WRITE readiness; heartbeat via
+  EVFILT_TIMER.  Shutdown uses a pipe + EVFILT_READ (async-signal-safe,
+  unlike kevent from a signal handler).  ~30 stubs for
+  backend-bookkeeping functions (io_conn_*, io_handle_*,
+  io_register_request, io_rpc_trans_cb) that live in
+  liburing-specific files on Linux -- these are TODOs, not
+  permanent.
+
+**Runtime proof**
+
+On witchie (FreeBSD 15, clang 19, base libc RPC): after merging
+PR 1 + substrate + PR 2 into a test branch, `./src/reffsd` compiles,
+links, and enters `main()`.  Startup banner prints:
+
+    reffsd 0.1.0 (git 36ca014d396c-dirty) starting -- role=standalone port=2049
+
+Fails next because `/var/lib/reffs/` doesn't exist -- a config-dir
+issue, not a port issue.  Creating the state dir would let reffsd
+proceed into the server-state initialization phase.
+
+**What doesn't work yet**
+
+On FreeBSD, `io_handle_{accept,connect,read,write}` stubs return
+`-ENOSYS`.  A real NFS request from a client will be accepted at the
+listen socket, but the completion path fails before the RPC is
+parsed.  The port is therefore **compile-and-link complete, not
+runtime complete**.
+
+**Next PR: kqueue runtime**
+
+The stub set in `backend_kqueue.c` is deliberately bounded -- one
+contiguous section near the bottom of the file, each stub
+commented with the Linux source location.  Porting them is:
+
+ 1. `io_handle_{accept,connect,read,write}` -- process completion
+    of the I/O the main loop dispatched.  Logic is socket buffer
+    management, TLS handshake driving, connection-state transitions.
+    Complexity: medium; mostly network bookkeeping.  Linux source:
+    `lib/io/accept.c`, `connect.c`, `read.c`, `write.c`.
+
+ 2. `io_conn_*` bookkeeping -- per-fd op counters and state.  Can
+    be moved to a shared (backend-agnostic) compilation unit; the
+    existing `lib/io/connect.c` state has nothing io_uring-specific
+    in it.
+
+ 3. `io_register_request` / `io_unregister_request` /
+    `io_find_request_by_xid` -- pending-RPC-by-XID table.  Same
+    story: move to shared.
+
+ 4. `io_rpc_trans_cb` -- submits an RPC reply write.  The Linux
+    version in `write.c` calls a static `rpc_trans_writer`.
+    FreeBSD needs an equivalent that uses the kqueue write path
+    via `io_request_write_op`.
+
+Estimate: 2-3 days for a reviewable PR that gets reffsd serving
+basic NFSv4.2 requests on FreeBSD.
+
+**Merge order**
+
+PR 1 → substrate → PR 2.  Substrate has textual conflicts with
+PR 1 on `src/reffsd.c` and `src/probe1_client.c`: substrate's
+`(sig_atomic_t){0}` compound-literal fix touches the same lines PR 1
+restructured from stack-allocated `rc` to heap.  Resolution: keep
+both -- PR 1's `ring_context_alloc()` lifecycle wins for `rc`;
+substrate's `sig_atomic_t` compound-literal wins for the
+`__atomic_store` compound argument.

--- a/lib/include/reffs/io.h
+++ b/lib/include/reffs/io.h
@@ -6,8 +6,8 @@
 #ifndef _REFFS_IO_H
 #define _REFFS_IO_H
 
+#include <signal.h>
 #include <stdint.h>
-#include <liburing.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <sys/socket.h>

--- a/lib/include/reffs/ring.h
+++ b/lib/include/reffs/ring.h
@@ -6,14 +6,26 @@
 #ifndef _REFFS_RING_H
 #define _REFFS_RING_H
 
-#include <stdint.h>
-#include <liburing.h>
-#include <pthread.h>
+/*
+ * struct ring_context is opaque to callers outside lib/io/.  The full
+ * definition lives in lib/io/ring_internal.h so that <liburing.h>
+ * stays contained inside the I/O layer, leaving room for non-Linux
+ * backends (FreeBSD aio+kqueue, thread pool).  See
+ * docs/io-backend-port-plan.md.
+ */
+struct ring_context;
 
-struct ring_context {
-	struct io_uring rc_ring;
-	pthread_mutex_t rc_mutex;
-	int rc_shutdown_efd; /* eventfd for signal-safe shutdown wakeup */
-};
+/*
+ * Allocate / free a ring_context.  Because the struct is opaque,
+ * callers cannot stack-allocate it and must use these helpers.
+ * The lifecycle is:
+ *     rc = ring_context_alloc();
+ *     io_handler_init(rc, ...)  or  io_backend_init(rc);
+ *     ... use ...
+ *     io_handler_fini(rc)  or  io_backend_fini(rc);
+ *     ring_context_free(rc);
+ */
+struct ring_context *ring_context_alloc(void);
+void ring_context_free(struct ring_context *rc);
 
 #endif /* _REFFS_RING_H */

--- a/lib/include/reffs/rpc.h
+++ b/lib/include/reffs/rpc.h
@@ -21,8 +21,6 @@
 
 #include <time.h>
 
-#include <liburing.h>
-
 #include <hdr/hdr_histogram.h>
 
 #include "reffs/ring.h"

--- a/lib/include/reffs/task.h
+++ b/lib/include/reffs/task.h
@@ -9,7 +9,6 @@
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <unistd.h>
-#include <liburing.h>
 #include "reffs/ring.h"
 #include "reffs/network.h"
 

--- a/lib/io/accept.c
+++ b/lib/io/accept.c
@@ -27,7 +27,7 @@
 #include "reffs/network.h"
 #include "reffs/ring.h"
 #include "ring_internal.h"
-#include "tsan_uring.h"
+#include "tsan_io.h"
 #include "reffs/trace/io.h"
 
 struct accept_context {

--- a/lib/io/accept.c
+++ b/lib/io/accept.c
@@ -26,6 +26,7 @@
 #include "reffs/log.h"
 #include "reffs/network.h"
 #include "reffs/ring.h"
+#include "ring_internal.h"
 #include "tsan_uring.h"
 #include "reffs/trace/io.h"
 

--- a/lib/io/backend.c
+++ b/lib/io/backend.c
@@ -44,6 +44,7 @@
 #include "reffs/log.h"
 #include "reffs/io.h"
 #include "reffs/ring.h"
+#include "ring_internal.h"
 #include "reffs/rpc.h"
 #include "reffs/task.h"
 
@@ -332,4 +333,26 @@ int io_request_backend_pwrite(int fd, const void *buf, size_t len, off_t offset,
 			    (uint64_t)offset);
 
 	return submit_backend_op(ic, sqe, rc);
+}
+
+/* ------------------------------------------------------------------ */
+/* ring_context lifecycle                                             */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Allocator for the opaque ring_context.  Callers outside lib/io/
+ * cannot stack-allocate because the struct is incomplete in the
+ * public header (see lib/include/reffs/ring.h).  The caller follows
+ * with io_handler_init() or io_backend_init() to populate the struct;
+ * ring_context_free() expects the caller to have already torn down
+ * the struct via the matching fini.
+ */
+struct ring_context *ring_context_alloc(void)
+{
+	return calloc(1, sizeof(struct ring_context));
+}
+
+void ring_context_free(struct ring_context *rc)
+{
+	free(rc);
 }

--- a/lib/io/backend.c
+++ b/lib/io/backend.c
@@ -29,7 +29,7 @@
 #include <errno.h>
 #include <liburing.h>
 
-#include "tsan_uring.h"
+#include "tsan_io.h"
 #include <liburing/io_uring.h>
 #include <linux/time_types.h>
 #include <pthread.h>

--- a/lib/io/connect.c
+++ b/lib/io/connect.c
@@ -27,6 +27,7 @@
 #include "reffs/log.h"
 #include "reffs/network.h"
 #include "reffs/ring.h"
+#include "ring_internal.h"
 #include "reffs/rpc.h"
 #include "reffs/trace/io.h"
 

--- a/lib/io/handler.c
+++ b/lib/io/handler.c
@@ -28,7 +28,7 @@
 #include "reffs/io.h"
 #include "reffs/ring.h"
 #include "ring_internal.h"
-#include "tsan_uring.h"
+#include "tsan_io.h"
 #include "reffs/rpc.h"
 #include "reffs/trace/io.h"
 

--- a/lib/io/handler.c
+++ b/lib/io/handler.c
@@ -27,6 +27,7 @@
 #include "reffs/log.h"
 #include "reffs/io.h"
 #include "reffs/ring.h"
+#include "ring_internal.h"
 #include "tsan_uring.h"
 #include "reffs/rpc.h"
 #include "reffs/trace/io.h"

--- a/lib/io/heartbeat.c
+++ b/lib/io/heartbeat.c
@@ -20,6 +20,7 @@
 #include "reffs/io.h"
 #include "reffs/log.h"
 #include "reffs/ring.h"
+#include "ring_internal.h"
 
 // Heartbeat interval in seconds
 #define HEARTBEAT_INTERVAL 1

--- a/lib/io/read.c
+++ b/lib/io/read.c
@@ -28,6 +28,7 @@
 #include "reffs/log.h"
 #include "reffs/network.h"
 #include "reffs/ring.h"
+#include "ring_internal.h"
 #include "tsan_uring.h"
 #include "reffs/rpc.h"
 #include "reffs/task.h"

--- a/lib/io/read.c
+++ b/lib/io/read.c
@@ -29,7 +29,7 @@
 #include "reffs/network.h"
 #include "reffs/ring.h"
 #include "ring_internal.h"
-#include "tsan_uring.h"
+#include "tsan_io.h"
 #include "reffs/rpc.h"
 #include "reffs/task.h"
 #include "reffs/tls.h"

--- a/lib/io/ring_internal.h
+++ b/lib/io/ring_internal.h
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Tom Haynes <loghyr@gmail.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/*
+ * Private definition of struct ring_context.
+ *
+ * The public header lib/include/reffs/ring.h forward-declares
+ * struct ring_context so callers outside lib/io/ hold it opaquely
+ * (they only ever see the pointer).  Code inside lib/io/ that
+ * dereferences the struct includes this header to get the full
+ * definition.
+ *
+ * This split keeps <liburing.h> out of public headers, which is a
+ * prerequisite for FreeBSD and macOS backends that do not have
+ * liburing at all.  See docs/io-backend-port-plan.md.
+ */
+
+#ifndef _REFFS_IO_RING_INTERNAL_H
+#define _REFFS_IO_RING_INTERNAL_H
+
+#include <liburing.h>
+#include <pthread.h>
+
+#include "reffs/ring.h"
+
+struct ring_context {
+	struct io_uring rc_ring;
+	pthread_mutex_t rc_mutex;
+	int rc_shutdown_efd; /* eventfd for signal-safe shutdown wakeup */
+};
+
+#endif /* _REFFS_IO_RING_INTERNAL_H */

--- a/lib/io/tsan_io.h
+++ b/lib/io/tsan_io.h
@@ -13,8 +13,8 @@
  *   TSAN_ACQUIRE(ic) in CQE handler after loading ic from user_data
  */
 
-#ifndef _REFFS_TSAN_URING_H
-#define _REFFS_TSAN_URING_H
+#ifndef _REFFS_TSAN_IO_H
+#define _REFFS_TSAN_IO_H
 
 #if defined(__SANITIZE_THREAD__) || defined(__has_feature)
 #if defined(__SANITIZE_THREAD__) || __has_feature(thread_sanitizer)
@@ -29,4 +29,4 @@
 #define TSAN_ACQUIRE(addr) ((void)(addr))
 #endif
 
-#endif /* _REFFS_TSAN_URING_H */
+#endif /* _REFFS_TSAN_IO_H */

--- a/lib/io/tsan_io.h
+++ b/lib/io/tsan_io.h
@@ -2,15 +2,17 @@
  * SPDX-FileCopyrightText: 2026 Tom Haynes <loghyr@gmail.com>
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * TSAN annotations for io_uring synchronization.
+ * TSAN annotations for I/O backend submission/completion synchronization.
  *
- * io_uring submission acts as a kernel-mediated memory barrier between
- * the SQE producer and the CQE consumer.  TSAN cannot model this, so
- * we annotate it explicitly.
+ * Backend submission (io_uring submit, aio_*, thread-pool enqueue) acts
+ * as a memory barrier between the submitter and the completion handler.
+ * TSAN cannot model the kernel- or thread-pool-mediated handoff, so we
+ * annotate it explicitly.
  *
  * Usage:
- *   TSAN_RELEASE(ic) after io_uring_submit succeeds
- *   TSAN_ACQUIRE(ic) in CQE handler after loading ic from user_data
+ *   TSAN_RELEASE(ic) after submission succeeds
+ *   TSAN_ACQUIRE(ic) in the completion handler after retrieving ic from
+ *                    the completion record's user_data
  */
 
 #ifndef _REFFS_TSAN_IO_H

--- a/lib/io/write.c
+++ b/lib/io/write.c
@@ -28,7 +28,7 @@
 #include "reffs/network.h"
 #include "reffs/ring.h"
 #include "ring_internal.h"
-#include "tsan_uring.h"
+#include "tsan_io.h"
 #include "reffs/rpc.h"
 #include "reffs/tls.h"
 #include "reffs/trace/io.h"

--- a/lib/io/write.c
+++ b/lib/io/write.c
@@ -27,6 +27,7 @@
 #include "reffs/log.h"
 #include "reffs/network.h"
 #include "reffs/ring.h"
+#include "ring_internal.h"
 #include "tsan_uring.h"
 #include "reffs/rpc.h"
 #include "reffs/tls.h"

--- a/lib/nfs4/server/chunk.c
+++ b/lib/nfs4/server/chunk.c
@@ -25,6 +25,7 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
 #include <zlib.h>
 

--- a/lib/nfs4/server/delegation.c
+++ b/lib/nfs4/server/delegation.c
@@ -10,6 +10,7 @@
 #include <pthread.h>
 #include <stdatomic.h>
 #include <string.h>
+#include <sys/stat.h>
 
 #include "nfsv42_xdr.h"
 #include "nfsv42_names.h"

--- a/src/probe1_client.c
+++ b/src/probe1_client.c
@@ -177,7 +177,7 @@ int main(int argc, char *argv[])
 
 	struct rpc_trans *rt = NULL;
 
-	struct ring_context rc;
+	struct ring_context *rc = NULL;
 
 	char *trace_file = "./probe1_clnt.log";
 
@@ -270,8 +270,13 @@ int main(int argc, char *argv[])
 	// Block signals in main thread temporarily
 	pthread_sigmask(SIG_BLOCK, &mask, NULL);
 
+	rc = ring_context_alloc();
+	if (!rc)
+		return 1;
+
 	// Initialize IO handler
-	if (io_handler_init(&rc, NULL, NULL, NULL) < 0) {
+	if (io_handler_init(rc, NULL, NULL, NULL) < 0) {
+		ring_context_free(rc);
 		return 1;
 	}
 
@@ -333,7 +338,7 @@ int main(int argc, char *argv[])
 	rt->rt_port = port;
 	rt->rt_addr_str = server;
 
-	rt->rt_rc = &rc;
+	rt->rt_rc = rc;
 
 	ret = io_send_request(rt);
 	if (ret) {
@@ -346,11 +351,13 @@ int main(int argc, char *argv[])
 	__atomic_store(&running, &(int){ 1 }, __ATOMIC_SEQ_CST);
 
 	// Run the main IO processing loop
-	io_handler_main_loop(&running, &rc);
+	io_handler_main_loop(&running, rc);
 
 	TRACE("Main loop exited, cleaning up...");
 
-	io_handler_fini(&rc);
+	io_handler_fini(rc);
+	ring_context_free(rc);
+	rc = NULL;
 
 done:
 	running = 0;

--- a/src/reffsd.c
+++ b/src/reffsd.c
@@ -153,8 +153,8 @@ int main(int argc, char *argv[])
 	int port = NFS_PORT;
 	int opt;
 
-	struct ring_context rc;
-	struct ring_context rc_backend;
+	struct ring_context *rc = NULL;
+	struct ring_context *rc_backend = NULL;
 	bool rc_backend_inited = false;
 	pthread_t backend_thread;
 	bool backend_thread_started = false;
@@ -348,18 +348,28 @@ int main(int argc, char *argv[])
 		ss->ss_nflavors = 1;
 	}
 
+	rc = ring_context_alloc();
+	rc_backend = ring_context_alloc();
+	if (!rc || !rc_backend) {
+		LOG("ring_context_alloc failed");
+		exit_code = 1;
+		goto out;
+	}
+
 	// Initialize IO handler
-	if (io_handler_init(&rc, cfg.tls_cert, cfg.tls_key, NULL) < 0) {
-		return 1;
+	if (io_handler_init(rc, cfg.tls_cert, cfg.tls_key, NULL) < 0) {
+		exit_code = 1;
+		goto out;
 	}
 
 	// Initialize backend file-I/O ring
-	if (io_backend_init(&rc_backend) < 0) {
-		io_handler_fini(&rc);
-		return 1;
+	if (io_backend_init(rc_backend) < 0) {
+		io_handler_fini(rc);
+		exit_code = 1;
+		goto out;
 	}
 	rc_backend_inited = true;
-	io_backend_set_global(&rc_backend);
+	io_backend_set_global(rc_backend);
 
 	// Set up protocol handlers
 	if (nfs4_protocol_register()) {
@@ -607,7 +617,7 @@ int main(int argc, char *argv[])
 	}
 
 	io_add_listener(lsnr_ipv4_nfs_fd);
-	io_request_accept_op(lsnr_ipv4_nfs_fd, NULL, &rc);
+	io_request_accept_op(lsnr_ipv4_nfs_fd, NULL, rc);
 
 	lsnr_ipv6_nfs_fd = io_lsnr_setup_ipv6(port);
 	if (lsnr_ipv6_nfs_fd < 0) {
@@ -617,7 +627,7 @@ int main(int argc, char *argv[])
 	}
 
 	io_add_listener(lsnr_ipv6_nfs_fd);
-	io_request_accept_op(lsnr_ipv6_nfs_fd, NULL, &rc);
+	io_request_accept_op(lsnr_ipv6_nfs_fd, NULL, rc);
 
 	lsnr_ipv4_probe_fd = io_lsnr_setup_ipv4(PROBE_PORT);
 	if (lsnr_ipv4_probe_fd < 0) {
@@ -627,7 +637,7 @@ int main(int argc, char *argv[])
 	}
 
 	io_add_listener(lsnr_ipv4_probe_fd);
-	io_request_accept_op(lsnr_ipv4_probe_fd, NULL, &rc);
+	io_request_accept_op(lsnr_ipv4_probe_fd, NULL, rc);
 
 	lsnr_ipv6_probe_fd = io_lsnr_setup_ipv6(PROBE_PORT);
 	if (lsnr_ipv6_probe_fd < 0) {
@@ -637,7 +647,7 @@ int main(int argc, char *argv[])
 	}
 
 	io_add_listener(lsnr_ipv6_probe_fd);
-	io_request_accept_op(lsnr_ipv6_probe_fd, NULL, &rc);
+	io_request_accept_op(lsnr_ipv6_probe_fd, NULL, rc);
 
 	/* aggressive cleanup of old registrations */
 	for (int v = 1; v <= 4; v++) {
@@ -729,7 +739,7 @@ int main(int argc, char *argv[])
 
 	// Spawn backend file-I/O ring thread
 	struct backend_thread_args bta = { .running = &running,
-					   .rc = &rc_backend };
+					   .rc = rc_backend };
 	if (pthread_create(&backend_thread, NULL, backend_thread_fn, &bta) !=
 	    0) {
 		LOG("Failed to create backend io_uring thread");
@@ -740,7 +750,7 @@ int main(int argc, char *argv[])
 
 	// Run the main IO processing loop
 
-	io_handler_main_loop(&running, &rc);
+	io_handler_main_loop(&running, rc);
 
 	/*
 	 * Shutdown ordering:
@@ -776,7 +786,7 @@ int main(int argc, char *argv[])
 
 	trace_lifecycle_shutdown(__func__, __LINE__,
 				 "draining worker and backend threads");
-	io_handler_fini(&rc);
+	io_handler_fini(rc);
 
 	pthread_join(backend_thread, NULL);
 	backend_thread_started = false;
@@ -798,7 +808,10 @@ out:
 	pmap_unset(NFS4_PROGRAM, NFS_V4);
 
 	if (rc_backend_inited)
-		io_backend_fini(&rc_backend);
+		io_backend_fini(rc_backend);
+
+	ring_context_free(rc);
+	ring_context_free(rc_backend);
 
 	pthread_sigmask(SIG_UNBLOCK, &mask, NULL);
 


### PR DESCRIPTION
## Summary

Prep work for FreeBSD + macOS I/O backends.  Public headers in
\`lib/include/reffs/\` no longer pull \`<liburing.h>\`.

- \`struct ring_context\` becomes opaque in \`lib/include/reffs/ring.h\`.
  Full definition moves to a new private \`lib/io/ring_internal.h\`.
  Two new lifecycle helpers (\`ring_context_alloc\` / \`_free\`) let
  callers outside \`lib/io/\` hold ring_context by pointer only.
- Three dead \`#include <liburing.h>\` lines removed from \`io.h\`,
  \`task.h\`, \`rpc.h\`.  Two files that were relying on transitive
  pulls gain explicit \`#include <signal.h>\` (for \`sig_atomic_t\`) and
  \`#include <sys/stat.h>\` (for \`S_ISREG\` / \`S_ISDIR\`).
- \`lib/io/tsan_uring.h\` → \`lib/io/tsan_io.h\`.  Content unchanged; the
  file's TSAN macros are already io_uring-agnostic.
- \`docs/io-backend-port-plan.md\` (new): design + status doc for the
  full three-backend (liburing / kqueue / threadpool) plan.  Future
  PRs land kqueue and threadpool against the abstraction this PR
  exposes.

## Test plan

- [x] \`make check\` on shadow: 114/114 pass
- [x] No new compiler warnings (-Werror clean)
- [x] \`grep -r liburing lib/include/\` returns only a comment

## Merge order

This is the first of a three-branch stack:

1. **This PR** (opaque ring_context)
2. \`feature/freebsd-substrate\` — FreeBSD build-level compat
3. \`feature/io-backend-kqueue\` — kqueue backend (depends on both)

See \`docs/io-backend-port-plan.md\` for the full plan.