### PR TITLE
freebsd: configure + build portability fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,10 @@ AS_CASE([$host_os],
         # ENODATA is also glibc-only ("no data available"); FreeBSD
         # has ENOATTR in the same role (especially for xattrs).
         CPPFLAGS="-DENODATA=ENOATTR $CPPFLAGS"
+        # backtrace(3) / backtrace_symbols(3) are in glibc on Linux
+        # but in a separate libexecinfo on FreeBSD.  Link it
+        # globally so every binary gets the symbols.
+        LIBS="-lexecinfo $LIBS"
         host_is_freebsd=yes
     ])
 AM_CONDITIONAL([HOST_FREEBSD], [test "x$host_is_freebsd" = "xyes"])

--- a/configure.ac
+++ b/configure.ac
@@ -443,6 +443,15 @@ AC_SUBST([OPENSSL_CFLAGS])
 AC_SUBST([OPENSSL_LIBS])
 
 # Check for libgssapi_krb5 (optional — RPCSEC_GSS disabled without it)
+# <rpc/auth_gss.h> is part of libtirpc on Linux (the SunRPC/GSS
+# integration header).  FreeBSD has its own GSS-RPC in the
+# gssrpc/ namespace with a different API and does not provide
+# <rpc/auth_gss.h>.  Check separately so mds_session.c can gate
+# its libtirpc-specific block on this, not on HAVE_GSSAPI_KRB5
+# (which only says GSSAPI is available, not that the SunRPC
+# integration glue exists).
+AC_CHECK_HEADERS([rpc/auth_gss.h])
+
 PKG_CHECK_MODULES([GSSAPI], [krb5-gssapi], [
     AC_DEFINE([HAVE_GSSAPI_KRB5], [1], [Define if libgssapi_krb5 is available])
 ], [

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,18 @@ AC_PROG_CC
 AC_USE_SYSTEM_EXTENSIONS
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 
+# FreeBSD installs headers and libraries under /usr/local by default
+# and the base toolchain does not search there unless told to.  Add
+# the standard pkg path so subsequent AC_CHECK_HEADER / AC_CHECK_LIB
+# probes can find ports-installed dependencies (libuuid,
+# HdrHistogram_c, etc.).
+AC_CANONICAL_HOST
+AS_CASE([$host_os],
+    [freebsd*|dragonfly*], [
+        CPPFLAGS="-I/usr/local/include $CPPFLAGS"
+        LDFLAGS="-L/usr/local/lib $LDFLAGS"
+    ])
+
 AC_MSG_CHECKING([for C11 support])
 dnl Strip out the freaking -O2 by default!
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[])],
@@ -66,8 +78,24 @@ PKG_CHECK_MODULES(URCU, liburcu, ,
 PKG_CHECK_MODULES(URCU_CDS, liburcu-cds, ,
     [AC_MSG_ERROR([Could not configure liburcu-cds support.])])
 
-PKG_CHECK_MODULES(TIRPC, libtirpc, ,
-    [AC_MSG_ERROR([Could not configure libtirpc support.])])
+# SunRPC lives in glibc's legacy tree on Linux (deprecated since
+# glibc 2.26) and is typically replaced by libtirpc.  FreeBSD ships
+# SunRPC in base libc, with identical <rpc/*.h> include paths and no
+# separate library.  Try libtirpc first; on failure, fall back to
+# empty CFLAGS/LIBS which makes the RPC calls resolve against base
+# libc.  Explicit detection of FreeBSD via host_os lets us skip the
+# misleading "Could not configure libtirpc" error there.
+AS_CASE([$host_os],
+    [freebsd*|dragonfly*], [
+        TIRPC_CFLAGS=""
+        TIRPC_LIBS=""
+        AC_SUBST([TIRPC_CFLAGS])
+        AC_SUBST([TIRPC_LIBS])
+    ],
+    [
+        PKG_CHECK_MODULES(TIRPC, libtirpc, ,
+            [AC_MSG_ERROR([Could not configure libtirpc support.])])
+    ])
 
 PKG_CHECK_MODULES([CHECK], [check >= 0.15.2])
 
@@ -76,7 +104,14 @@ AC_SUBST(PTHREAD_CFLAGS)
 
 PKG_CHECK_MODULES(XXHASH, libxxhash, , [AC_MSG_ERROR([Could not configure xxhash support.])])
 
-PKG_CHECK_MODULES(FUSE, fuse, , [AC_MSG_ERROR([Could not configure fuse support.])])
+# libfuse pkg-config module name differs by platform: "fuse" on
+# Linux (libfuse2/libfuse3 via the fuse or fuse3 module) and "fuse3"
+# on FreeBSD (fusefs-libs3).  Try both.
+PKG_CHECK_MODULES(FUSE, fuse3, , [
+    PKG_CHECK_MODULES(FUSE, fuse, , [
+        AC_MSG_ERROR([Could not configure fuse support (tried fuse3, fuse).])
+    ])
+])
 
 # Check for programs
 AC_PATH_PROG([GIT], [git], [no])
@@ -141,9 +176,9 @@ AC_SUBST([ZSTD_LIBS])
 
 # Check for io_uring support
 AC_ARG_ENABLE([linux-io_uring],
-    [AS_HELP_STRING([--enable-linux-io_uring], [enable Linux io_uring support @<:@default=yes@:>@])],
+    [AS_HELP_STRING([--enable-linux-io_uring], [enable Linux io_uring support @<:@default=auto@:>@])],
     [],
-    [enable_linux_io_uring=yes])
+    [enable_linux_io_uring=auto])
 
 # Check for strict POSIX support
 AC_ARG_ENABLE([strict-posix],
@@ -364,8 +399,25 @@ else
 fi
 
 # Check for HdrHistogram_c
-AC_CHECK_HEADERS([hdr/hdr_histogram.h], [], [AC_MSG_ERROR([hdr_histogram.h not found. Please install HdrHistogram_c-devel])])
-AC_CHECK_LIB([hdr_histogram], [hdr_init], [], [AC_MSG_ERROR([libhdr_histogram not found. Please install HdrHistogram_c])])
+# HdrHistogram_c is packaged on most Linux distros (HdrHistogram_c-devel)
+# but not in FreeBSD ports.  Treat as optional: define HAVE_HDR_HISTOGRAM
+# when present; source files gate histogram code with #ifdef.  If
+# missing on Linux, emit a warning -- histograms are soft telemetry.
+AC_CHECK_HEADERS([hdr/hdr_histogram.h], [
+    AC_DEFINE([HAVE_HDR_HISTOGRAM], [1],
+              [Define if HdrHistogram_c is available])
+], [
+    AC_MSG_WARN([hdr_histogram.h not found; histogram telemetry will be disabled.  On Linux, install HdrHistogram_c-devel.])
+])
+AS_IF([test "x$ac_cv_header_hdr_hdr_histogram_h" = "xyes"], [
+    AC_CHECK_LIB([hdr_histogram], [hdr_init], [
+        HDR_HISTOGRAM_LIBS="-lhdr_histogram"
+    ], [
+        AC_MSG_WARN([libhdr_histogram library not found; histogram telemetry will be disabled.])
+        ac_cv_header_hdr_hdr_histogram_h=no
+    ])
+])
+AC_SUBST([HDR_HISTOGRAM_LIBS])
 
 # Check for OpenSSL
 PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.0.2], [],

--- a/configure.ac
+++ b/configure.ac
@@ -461,6 +461,12 @@ PKG_CHECK_MODULES([ROCKSDB], [rocksdb], [
     AC_MSG_WARN([RocksDB not found — RocksDB metadata backend disabled])
     have_rocksdb=no
 ])
+# FreeBSD's rocksdb.pc ships a broken LDFLAGS fragment
+# ("-Wl,-rpath -Wl,") which the linker cannot parse -- it reads
+# the empty argument as a library name and fails with "cannot
+# open libbackends.so.0".  Strip the fragment; the -L/usr/local/lib
+# that pkg-config emits alongside makes the library findable.
+ROCKSDB_LIBS=`echo "$ROCKSDB_LIBS" | sed -e 's/-Wl,-rpath[[ 	]]*-Wl,[[ 	]]*//g'`
 AC_SUBST([ROCKSDB_CFLAGS])
 AC_SUBST([ROCKSDB_LIBS])
 AM_CONDITIONAL([HAVE_ROCKSDB], [test "x$have_rocksdb" = "xyes"])

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,13 @@ AS_CASE([$host_os],
         # get bool_t in scope.  Linux's libtirpc pulls types.h in from
         # xdr.h itself; FreeBSD's base libc xdr.h does not.
         CPPFLAGS="-include rpc/rpc.h $CPPFLAGS"
+        # EREMOTEIO is a glibc-specific errno.  FreeBSD has no
+        # distinct "remote I/O error" code; alias to EIO so all
+        # -EREMOTEIO return statements compile.
+        CPPFLAGS="-DEREMOTEIO=EIO $CPPFLAGS"
+        # ENODATA is also glibc-only ("no data available"); FreeBSD
+        # has ENOATTR in the same role (especially for xattrs).
+        CPPFLAGS="-DENODATA=ENOATTR $CPPFLAGS"
         host_is_freebsd=yes
     ])
 AM_CONDITIONAL([HOST_FREEBSD], [test "x$host_is_freebsd" = "xyes"])

--- a/configure.ac
+++ b/configure.ac
@@ -39,11 +39,14 @@ m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 # probes can find ports-installed dependencies (libuuid,
 # HdrHistogram_c, etc.).
 AC_CANONICAL_HOST
+host_is_freebsd=no
 AS_CASE([$host_os],
     [freebsd*|dragonfly*], [
         CPPFLAGS="-I/usr/local/include $CPPFLAGS"
         LDFLAGS="-L/usr/local/lib $LDFLAGS"
+        host_is_freebsd=yes
     ])
+AM_CONDITIONAL([HOST_FREEBSD], [test "x$host_is_freebsd" = "xyes"])
 
 AC_MSG_CHECKING([for C11 support])
 dnl Strip out the freaking -O2 by default!

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,11 @@ AS_CASE([$host_os],
     [freebsd*|dragonfly*], [
         CPPFLAGS="-I/usr/local/include $CPPFLAGS"
         LDFLAGS="-L/usr/local/lib $LDFLAGS"
+        # Force-include <rpc/types.h> on every compilation unit so
+        # generated XDR headers (which #include <rpc/xdr.h> directly)
+        # get bool_t in scope.  Linux's libtirpc pulls types.h in from
+        # xdr.h itself; FreeBSD's base libc xdr.h does not.
+        CPPFLAGS="-include rpc/types.h $CPPFLAGS"
         host_is_freebsd=yes
     ])
 AM_CONDITIONAL([HOST_FREEBSD], [test "x$host_is_freebsd" = "xyes"])

--- a/configure.ac
+++ b/configure.ac
@@ -507,6 +507,18 @@ else
 	CFLAGS="${COMMON_FLAGS} -Wall -Wextra -Wpedantic -g -O0"
 fi
 
+AS_CASE([$host_os],
+    [freebsd*|dragonfly*], [
+        # FreeBSD's liburcu headers use two C extensions that
+        # -Wpedantic flags under -std=c11:
+        #   - named variadic macros (GCC extension)
+        #   - zero-argument variadic macro invocations (C23, used
+        #     by liburcu's _uatomic_default_mo pattern)
+        # Suppress both warning classes rather than drop -Wpedantic
+        # entirely.
+        CFLAGS="${CFLAGS} -Wno-variadic-macros -Wno-c23-extensions"
+    ])
+
 AC_MSG_RESULT([C flags are ${CFLAGS}])
 
 AC_SUBST([DEBUG_ENABLED])

--- a/configure.ac
+++ b/configure.ac
@@ -49,13 +49,16 @@ AS_CASE([$host_os],
         # get bool_t in scope.  Linux's libtirpc pulls types.h in from
         # xdr.h itself; FreeBSD's base libc xdr.h does not.
         CPPFLAGS="-include rpc/rpc.h $CPPFLAGS"
-        # EREMOTEIO is a glibc-specific errno.  FreeBSD has no
-        # distinct "remote I/O error" code; alias to EIO so all
-        # -EREMOTEIO return statements compile.
-        CPPFLAGS="-DEREMOTEIO=EIO $CPPFLAGS"
-        # ENODATA is also glibc-only ("no data available"); FreeBSD
-        # has ENOATTR in the same role (especially for xattrs).
-        CPPFLAGS="-DENODATA=ENOATTR $CPPFLAGS"
+        # EREMOTEIO and ENODATA are glibc-specific.  FreeBSD's
+        # ELAST is 97 (EINTEGRITY), so we assign reffs-internal
+        # values safely above that range — distinct from every
+        # POSIX/FreeBSD errno — so internal comparisons like
+        # `if (ret == -EREMOTEIO)` continue to work.  These values
+        # must never leave reffs: coerce to EIO / ENOATTR at any
+        # boundary (syscall return, NFS wire).  Must match the
+        # fallback in lib/include/reffs/log.h.
+        CPPFLAGS="-DEREMOTEIO=198 $CPPFLAGS"
+        CPPFLAGS="-DENODATA=199   $CPPFLAGS"
         # backtrace(3) / backtrace_symbols(3) are in glibc on Linux
         # but in a separate libexecinfo on FreeBSD.  Link it
         # globally so every binary gets the symbols.

--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ AS_CASE([$host_os],
         # generated XDR headers (which #include <rpc/xdr.h> directly)
         # get bool_t in scope.  Linux's libtirpc pulls types.h in from
         # xdr.h itself; FreeBSD's base libc xdr.h does not.
-        CPPFLAGS="-include rpc/types.h $CPPFLAGS"
+        CPPFLAGS="-include rpc/rpc.h $CPPFLAGS"
         host_is_freebsd=yes
     ])
 AM_CONDITIONAL([HOST_FREEBSD], [test "x$host_is_freebsd" = "xyes"])
@@ -516,7 +516,7 @@ AS_CASE([$host_os],
         #     by liburcu's _uatomic_default_mo pattern)
         # Suppress both warning classes rather than drop -Wpedantic
         # entirely.
-        CFLAGS="${CFLAGS} -Wno-variadic-macros -Wno-c23-extensions"
+        CFLAGS="${CFLAGS} -Wno-variadic-macros -Wno-c23-extensions -Wno-gnu"
     ])
 
 AC_MSG_RESULT([C flags are ${CFLAGS}])

--- a/lib/fs/Makefile.am
+++ b/lib/fs/Makefile.am
@@ -23,7 +23,6 @@ libreffs_fs_la_SOURCES = \
 	evictor.c \
 	filehandle.c \
 	fs.c \
-	fuse.c \
 	inode.c \
 	layout_segment.c \
 	lock.c \
@@ -32,5 +31,13 @@ libreffs_fs_la_SOURCES = \
 	stateid.c \
 	super_block.c \
 	vfs.c
+
+# fuse.c wraps libfuse callbacks for a userspace mount utility and
+# is only needed on Linux at the moment.  Its callback signatures
+# target libfuse2-era APIs (4-arg readdir) while FreeBSD ships only
+# libfuse3 (5-arg).  Port separately; for now, skip on FreeBSD.
+if !HOST_FREEBSD
+libreffs_fs_la_SOURCES += fuse.c
+endif
 
 libreffs_fs_la_LIBADD = $(top_builddir)/lib/backends/libbackends.la

--- a/lib/fs/fuse.c
+++ b/lib/fs/fuse.c
@@ -9,7 +9,11 @@
 
 #define FUSE_USE_VERSION 31
 
-#include <fuse/fuse.h>
+/* pkg-config's -I for libfuse3 points at the dir containing fuse.h
+ * (Linux: /usr/include/fuse3; FreeBSD: /usr/local/include/fuse3), so
+ * the bare form works on both.  The older <fuse/fuse.h> path works
+ * only with Linux's libfuse2. */
+#include <fuse.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/lib/fs/tests/fs_test_vfs_ctime_capture.c
+++ b/lib/fs/tests/fs_test_vfs_ctime_capture.c
@@ -29,7 +29,9 @@
 #endif
 
 #include <sys/stat.h>
+#if defined(__linux__)
 #include <sys/sysmacros.h>
+#endif
 #include <rpc/rpc.h>
 
 #include "fs_test_harness.h"

--- a/lib/fs/vfs.c
+++ b/lib/fs/vfs.c
@@ -14,7 +14,9 @@
 #include <stdint.h>
 #include <string.h>
 #include <sys/stat.h>
+#if defined(__linux__)
 #include <sys/sysmacros.h>
+#endif
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>

--- a/lib/include/reffs/log.h
+++ b/lib/include/reffs/log.h
@@ -10,13 +10,21 @@
 
 /*
  * Portability shim: Linux-only errno codes used throughout reffs.
- * EREMOTEIO is glibc-specific; FreeBSD has no distinct code for
- * "remote I/O error".  Fall back to EIO so code that returns
- * -EREMOTEIO stays compilable.  Callers that need to distinguish
- * remote vs local I/O errors should not rely on this.
+ *
+ * EREMOTEIO and ENODATA are glibc-specific.  FreeBSD's ELAST is 97
+ * (EINTEGRITY), so we assign reffs-internal values well above that
+ * range — distinct from every POSIX/FreeBSD errno — so internal
+ * comparisons like `if (ret == -EREMOTEIO)` continue to work.
+ *
+ * These values are reffs-internal only: if an error ever needs to
+ * cross a boundary (syscall return, NFS wire, kernel), coerce it to
+ * a POSIX errno (EIO for EREMOTEIO, ENOATTR for ENODATA).
  */
 #ifndef EREMOTEIO
-#define EREMOTEIO EIO
+#define EREMOTEIO 198
+#endif
+#ifndef ENODATA
+#define ENODATA   199
 #endif
 
 #include <stdio.h>

--- a/lib/include/reffs/log.h
+++ b/lib/include/reffs/log.h
@@ -6,6 +6,19 @@
 #ifndef _REFFS_LOG_H
 #define _REFFS_LOG_H
 
+#include <errno.h>
+
+/*
+ * Portability shim: Linux-only errno codes used throughout reffs.
+ * EREMOTEIO is glibc-specific; FreeBSD has no distinct code for
+ * "remote I/O error".  Fall back to EIO so code that returns
+ * -EREMOTEIO stays compilable.  Callers that need to distinguish
+ * remote vs local I/O errors should not rely on this.
+ */
+#ifndef EREMOTEIO
+#define EREMOTEIO EIO
+#endif
+
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/lib/include/reffs/log.h
+++ b/lib/include/reffs/log.h
@@ -13,12 +13,34 @@
 #include <stdarg.h>
 #include <stdatomic.h>
 #include <time.h>
+
+#if defined(__linux__)
 #include <sys/syscall.h>
+#elif defined(__FreeBSD__)
+#include <pthread_np.h>
+#endif
 
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #endif
+
+/*
+ * Portable kernel thread id accessor.  Linux: syscall(SYS_gettid).
+ * FreeBSD: pthread_getthreadid_np(), a non-portable extension.  Both
+ * return a small integer that uniquely identifies the kernel thread
+ * within the process; suitable for log/trace prefixes.
+ */
+static inline pid_t reffs_gettid(void)
+{
+#if defined(__linux__)
+	return (pid_t)syscall(SYS_gettid);
+#elif defined(__FreeBSD__)
+	return (pid_t)pthread_getthreadid_np();
+#else
+	return (pid_t)getpid();
+#endif
+}
 
 extern FILE *reffs_log_file;
 
@@ -28,7 +50,7 @@ extern FILE *reffs_log_file;
 		clock_gettime(CLOCK_REALTIME, &ts);                      \
 		struct tm *tm_info = localtime(&ts.tv_sec);              \
 		char time_str[32];                                       \
-		pid_t tid = syscall(SYS_gettid);                         \
+		pid_t tid = reffs_gettid();                         \
 		strftime(time_str, 20, "%Y-%m-%d %H:%M:%S", tm_info);    \
 		fprintf(stderr, "[%s.%09ld] [%d:%d] (%s:%d): " fmt "\n", \
 			time_str, ts.tv_nsec, getpid(), tid, __func__,   \
@@ -42,7 +64,7 @@ extern FILE *reffs_log_file;
 		clock_gettime(CLOCK_REALTIME, &ts);                        \
 		struct tm *tm_info = localtime(&ts.tv_sec);                \
 		char time_str[32];                                         \
-		pid_t tid = syscall(SYS_gettid);                           \
+		pid_t tid = reffs_gettid();                           \
 		strftime(time_str, 20, "%Y-%m-%d %H:%M:%S", tm_info);      \
 		fprintf(reffs_log_file ? reffs_log_file : stdout,          \
 			"[%s.%09ld] [%d:%d] (%s:%d): " fmt "\n", time_str, \

--- a/lib/include/reffs/network.h
+++ b/lib/include/reffs/network.h
@@ -7,6 +7,8 @@
 #define _REFFS_NETWORK_H
 
 #include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 #include <arpa/inet.h>
 #include <string.h>
 #include <stdbool.h>

--- a/lib/include/reffs/rpc.h
+++ b/lib/include/reffs/rpc.h
@@ -21,7 +21,14 @@
 
 #include <time.h>
 
+#ifdef HAVE_HDR_HISTOGRAM
 #include <hdr/hdr_histogram.h>
+#else
+/* Forward declaration so struct fields of type hdr_histogram *
+ * compile without the library.  Call sites that manipulate the
+ * histogram must be #ifdef HAVE_HDR_HISTOGRAM themselves. */
+struct hdr_histogram;
+#endif
 
 #include "reffs/ring.h"
 #include "reffs/network.h"

--- a/lib/include/reffs/tls.h
+++ b/lib/include/reffs/tls.h
@@ -9,6 +9,8 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
+#include "reffs/log.h" /* LOG() used in the inline helper below */
+
 #define AUTH_TLS 7
 #define STARTTLS_VERIFIER "STARTTLS"
 #define REFFS_TLS_HANDSHAKE 22 // Content type for TLS handshake

--- a/lib/nfs3/server.c
+++ b/lib/nfs3/server.c
@@ -18,7 +18,9 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#if defined(__linux__)
 #include <sys/sysmacros.h>
+#endif
 #include <rpc/xdr.h>
 #include <rpc/auth.h>
 #include <rpc/auth_unix.h>

--- a/lib/nfs4/client/Makefile.am
+++ b/lib/nfs4/client/Makefile.am
@@ -13,9 +13,15 @@ libreffs_nfs4_client_la_SOURCES = \
 	chunk_io.c \
 	ds_io.c \
 	mds_compound.c \
-	mds_session.c \
 	mds_file.c \
 	mds_layout.c \
 	ec_io.c
+
+# mds_session.c uses <rpc/auth_gss.h> which only exists on libtirpc.
+# FreeBSD's GSS-RPC lives in the gssrpc/ namespace (MIT Kerberos
+# port) with a different API.  Gate on Linux until a proper port.
+if !HOST_FREEBSD
+libreffs_nfs4_client_la_SOURCES += mds_session.c
+endif
 
 SUBDIRS = tests

--- a/lib/nfs4/client/Makefile.am
+++ b/lib/nfs4/client/Makefile.am
@@ -13,15 +13,9 @@ libreffs_nfs4_client_la_SOURCES = \
 	chunk_io.c \
 	ds_io.c \
 	mds_compound.c \
+	mds_session.c \
 	mds_file.c \
 	mds_layout.c \
 	ec_io.c
-
-# mds_session.c uses <rpc/auth_gss.h> which only exists on libtirpc.
-# FreeBSD's GSS-RPC lives in the gssrpc/ namespace (MIT Kerberos
-# port) with a different API.  Gate on Linux until a proper port.
-if !HOST_FREEBSD
-libreffs_nfs4_client_la_SOURCES += mds_session.c
-endif
 
 SUBDIRS = tests

--- a/lib/nfs4/client/chunk_io.c
+++ b/lib/nfs4/client/chunk_io.c
@@ -14,6 +14,7 @@
  */
 
 #include <errno.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/lib/nfs4/client/ds_io.c
+++ b/lib/nfs4/client/ds_io.c
@@ -14,6 +14,7 @@
  */
 
 #include <errno.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/lib/nfs4/client/mds_compound.c
+++ b/lib/nfs4/client/mds_compound.c
@@ -114,7 +114,12 @@ int mds_compound_send(struct mds_compound *mc, struct mds_session *ms)
 	ms->ms_slot_seqid++;
 
 	if (mc->mc_res.status != NFS4_OK)
+#if defined(EREMOTEIO)
 		return -EREMOTEIO;
+#else
+		/* FreeBSD has no EREMOTEIO.  Use the closest POSIX cousin. */
+		return -EIO;
+#endif
 
 	return 0;
 }

--- a/lib/nfs4/client/mds_compound.c
+++ b/lib/nfs4/client/mds_compound.c
@@ -114,12 +114,7 @@ int mds_compound_send(struct mds_compound *mc, struct mds_session *ms)
 	ms->ms_slot_seqid++;
 
 	if (mc->mc_res.status != NFS4_OK)
-#if defined(EREMOTEIO)
 		return -EREMOTEIO;
-#else
-		/* FreeBSD has no EREMOTEIO.  Use the closest POSIX cousin. */
-		return -EIO;
-#endif
 
 	return 0;
 }

--- a/lib/nfs4/client/mds_session.c
+++ b/lib/nfs4/client/mds_session.c
@@ -21,7 +21,20 @@
 
 #include <rpc/rpc.h>
 
-#ifdef HAVE_GSSAPI_KRB5
+/*
+ * GSS-RPC support requires BOTH:
+ *   - libgssapi_krb5 (HAVE_GSSAPI_KRB5) for the GSSAPI itself, and
+ *   - <rpc/auth_gss.h> (HAVE_RPC_AUTH_GSS_H) for the SunRPC/GSS
+ *     integration layer (shipped with libtirpc on Linux; absent on
+ *     FreeBSD base, whose gssrpc equivalent uses a different API).
+ * Both must be present, or the gated mds_session_create_sec block
+ * below returns -ENOSYS.
+ */
+#if defined(HAVE_GSSAPI_KRB5) && defined(HAVE_RPC_AUTH_GSS_H)
+#define REFFS_HAVE_GSS_RPC 1
+#endif
+
+#ifdef REFFS_HAVE_GSS_RPC
 #include <rpc/auth_gss.h>
 #include <gssapi/gssapi.h>
 #include <gssapi/gssapi_krb5.h>
@@ -360,7 +373,7 @@ err:
 int mds_session_create_sec(struct mds_session *ms, const char *host,
 			   enum ec_sec_flavor sec)
 {
-#ifdef HAVE_GSSAPI_KRB5
+#ifdef REFFS_HAVE_GSS_RPC
 	if (sec == EC_SEC_SYS)
 		return mds_session_create(ms, host);
 

--- a/lib/nfs4/server/compound.c
+++ b/lib/nfs4/server/compound.c
@@ -19,7 +19,9 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#if defined(__linux__)
 #include <sys/sysmacros.h>
+#endif
 #include <rpc/xdr.h>
 #include <rpc/auth.h>
 #include <rpc/auth_unix.h>

--- a/lib/nfs4/server/copy.c
+++ b/lib/nfs4/server/copy.c
@@ -16,6 +16,16 @@
 /* FICLONERANGE and related Linux-specific clone ioctls. */
 #include <linux/fs.h>
 #endif
+
+/*
+ * copy_file_range(2) takes 'loff_t *' on Linux and 'off_t *' on
+ * FreeBSD; both are signed 64-bit.  Alias to loff_t on FreeBSD so
+ * the call-site code below is identical.
+ */
+#if !defined(__linux__)
+typedef off_t loff_t;
+#endif
+
 #include <pthread.h>
 #include <stdatomic.h>
 #include <stdint.h>

--- a/lib/nfs4/server/copy.c
+++ b/lib/nfs4/server/copy.c
@@ -12,7 +12,10 @@
 #endif
 
 #include <errno.h>
+#if defined(__linux__)
+/* FICLONERANGE and related Linux-specific clone ioctls. */
 #include <linux/fs.h>
+#endif
 #include <pthread.h>
 #include <stdatomic.h>
 #include <stdint.h>
@@ -502,6 +505,7 @@ uint32_t nfs4_op_clone(struct compound *compound)
 		goto out;
 	}
 
+#if defined(__linux__)
 	struct file_clone_range fcr = {
 		.src_fd = src_fd,
 		.src_offset = src_offset,
@@ -524,6 +528,15 @@ uint32_t nfs4_op_clone(struct compound *compound)
 		}
 		goto out;
 	}
+#else
+	/* FreeBSD has no FICLONERANGE.  ZFS supports block cloning via
+	 * a different interface (copy_file_range(2) uses it on recent
+	 * releases); wiring that is out of scope for the substrate PR. */
+	(void)src_fd;
+	(void)dst_fd;
+	*status = NFS4ERR_NOTSUPP;
+	goto out;
+#endif
 
 	/*
 	 * Update destination size if the clone extended it.

--- a/lib/nfs4/server/dir.c
+++ b/lib/nfs4/server/dir.c
@@ -10,7 +10,9 @@
 #include <stdatomic.h>
 #include <string.h>
 #include <sys/stat.h>
+#if defined(__linux__)
 #include <sys/sysmacros.h>
+#endif
 #include <time.h>
 
 #include "nfsv42_xdr.h"

--- a/lib/nfs4/server/dispatch.c
+++ b/lib/nfs4/server/dispatch.c
@@ -17,7 +17,9 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#if defined(__linux__)
 #include <sys/sysmacros.h>
+#endif
 #include <rpc/xdr.h>
 #include <rpc/auth.h>
 #include <rpc/auth_unix.h>

--- a/lib/nfs4/server/register.c
+++ b/lib/nfs4/server/register.c
@@ -17,7 +17,9 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#if defined(__linux__)
 #include <sys/sysmacros.h>
+#endif
 #include <rpc/xdr.h>
 #include <rpc/auth.h>
 #include <rpc/auth_unix.h>

--- a/lib/probe1/probe1_server.c
+++ b/lib/probe1/probe1_server.c
@@ -70,6 +70,7 @@ static const int64_t rpc_bucket_boundaries[BUCKET_COUNT] = {
 	// Last bucket is >=10s
 };
 
+#ifdef HAVE_HDR_HISTOGRAM
 void calculate_bucket_counts(struct hdr_histogram *hh, int64_t *counts)
 {
 	struct hdr_iter iter;
@@ -102,6 +103,7 @@ void calculate_bucket_counts(struct hdr_histogram *hh, int64_t *counts)
 		counts[bucket_index] += count;
 	}
 }
+#endif /* HAVE_HDR_HISTOGRAM */
 
 void probe_fd1_get_addr(struct probe_fd1 *pf, struct connection_info *ci)
 {
@@ -200,6 +202,7 @@ static int probe1_op_stats_gather(struct rpc_trans *rt)
 			      &pp->pp_ops.pp_ops_val[i].po_total_duration,
 			      __ATOMIC_RELAXED);
 
+#ifdef HAVE_HDR_HISTOGRAM
 		struct hdr_histogram *hh =
 			rph->rph_ops[i].roh_stats.rs_histogram;
 		calculate_bucket_counts(hh, counts);
@@ -223,6 +226,25 @@ static int probe1_op_stats_gather(struct rpc_trans *rt)
 		pp->pp_ops.pp_ops_val[i].po_min_ns = hdr_min(hh);
 		pp->pp_ops.pp_ops_val[i].po_max_ns = hdr_max(hh);
 		pp->pp_ops.pp_ops_val[i].po_mean_ns = hdr_mean(hh);
+#else
+		/* No histogram library -- return zeros.  Build is still
+		 * possible on platforms without HdrHistogram_c (e.g.,
+		 * FreeBSD ports does not package it as of 2026-04). */
+		(void)counts;
+		pp->pp_ops.pp_ops_val[i].po_bucket_1ms = 0;
+		pp->pp_ops.pp_ops_val[i].po_bucket_10ms = 0;
+		pp->pp_ops.pp_ops_val[i].po_bucket_100ms = 0;
+		pp->pp_ops.pp_ops_val[i].po_bucket_1s = 0;
+		pp->pp_ops.pp_ops_val[i].po_bucket_10s = 0;
+		pp->pp_ops.pp_ops_val[i].po_bucket_rest = 0;
+		pp->pp_ops.pp_ops_val[i].po_median_ns = 0;
+		pp->pp_ops.pp_ops_val[i].po_p90_ns = 0;
+		pp->pp_ops.pp_ops_val[i].po_p99_ns = 0;
+		pp->pp_ops.pp_ops_val[i].po_p999_ns = 0;
+		pp->pp_ops.pp_ops_val[i].po_min_ns = 0;
+		pp->pp_ops.pp_ops_val[i].po_max_ns = 0;
+		pp->pp_ops.pp_ops_val[i].po_mean_ns = 0;
+#endif
 	}
 
 out:

--- a/lib/probe1/probe1_server.c
+++ b/lib/probe1/probe1_server.c
@@ -61,6 +61,7 @@ time_t probe_time1_to_time_t(struct probe_time1 pt)
 }
 
 #define BUCKET_COUNT 5
+#ifdef HAVE_HDR_HISTOGRAM
 static const int64_t rpc_bucket_boundaries[BUCKET_COUNT] = {
 	1000000, // 1ms
 	10000000, // 10ms
@@ -70,7 +71,6 @@ static const int64_t rpc_bucket_boundaries[BUCKET_COUNT] = {
 	// Last bucket is >=10s
 };
 
-#ifdef HAVE_HDR_HISTOGRAM
 void calculate_bucket_counts(struct hdr_histogram *hh, int64_t *counts)
 {
 	struct hdr_iter iter;

--- a/lib/rpc/rpc.c
+++ b/lib/rpc/rpc.c
@@ -9,7 +9,9 @@
 
 #include <assert.h>
 #include <errno.h>
+#ifdef HAVE_HDR_HISTOGRAM
 #include <hdr/hdr_histogram.h>
+#endif
 #include <rpc/auth.h>
 #include <rpc/auth_unix.h>
 #include <rpc/clnt.h>
@@ -71,10 +73,12 @@ static void rpc_program_handler_free_rcu(struct rcu_head *rcu)
 	struct rpc_program_handler *rph =
 		caa_container_of(rcu, struct rpc_program_handler, rph_rcu);
 
+#ifdef HAVE_HDR_HISTOGRAM
 	for (size_t i = 0; i < rph->rph_ops_len; i++) {
 		hdr_close(rph->rph_ops[i].roh_stats.rs_histogram);
 		rph->rph_ops[i].roh_stats.rs_histogram = NULL;
 	}
+#endif
 
 	free(rph);
 }
@@ -119,10 +123,12 @@ rpc_program_handler_alloc(uint32_t program, uint32_t version,
 	__atomic_fetch_or(&rph->rph_flags, RPH_IN_LIST, __ATOMIC_RELEASE);
 	cds_list_add_rcu(&rph->rph_list, &rpc_program_handler_list);
 
+#ifdef HAVE_HDR_HISTOGRAM
 	for (size_t i = 0; i < roh_len; i++) {
 		hdr_init(1, INT64_C(3600000000000), 3,
 			 &roh[i].roh_stats.rs_histogram);
 	}
+#endif
 
 	return rph;
 }
@@ -207,7 +213,11 @@ static void rpc_record_operation_stats(struct rpc_operations_handler *roh,
 		__atomic_fetch_add(&roh->roh_stats.rs_fails, 1,
 				   __ATOMIC_RELAXED);
 
+#ifdef HAVE_HDR_HISTOGRAM
 	hdr_record_value(roh->roh_stats.rs_histogram, duration_ns);
+#else
+	(void)duration_ns;
+#endif
 }
 
 int rpc_parse_call_data(struct rpc_trans *rt)

--- a/lib/trace/common.c
+++ b/lib/trace/common.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdarg.h>
-#include <sys/syscall.h>
 #include <inttypes.h>
 #include <unistd.h>
 #include <time.h>
@@ -21,6 +20,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <zstd.h>
+#include "reffs/log.h" /* reffs_gettid() */
 #include "reffs/trace/common.h"
 #include "reffs/trace/types.h"
 
@@ -325,7 +325,7 @@ void reffs_trace_event(enum reffs_trace_category category, const char *name,
 	}
 	last_event_ts = ts;
 
-	pid_t tid = syscall(SYS_gettid);
+	pid_t tid = reffs_gettid();
 
 	pthread_mutex_lock(&trace_mutex);
 	if (trace_fp != NULL) {

--- a/lib/utils/server.c
+++ b/lib/utils/server.c
@@ -20,6 +20,17 @@
 #include <unistd.h>
 #include <time.h>
 
+/* FreeBSD declares MAXHOSTNAMELEN (in <sys/param.h>) but not
+ * HOST_NAME_MAX (POSIX, not in the base headers by default). */
+#ifndef HOST_NAME_MAX
+#include <sys/param.h>
+#ifdef MAXHOSTNAMELEN
+#define HOST_NAME_MAX MAXHOSTNAMELEN
+#else
+#define HOST_NAME_MAX 256
+#endif
+#endif
+
 #include "reffs/cmp.h"
 #include "reffs/rcu.h"
 #include "reffs/log.h"

--- a/lib/xdr/Makefile.am
+++ b/lib/xdr/Makefile.am
@@ -5,6 +5,14 @@ ACLOCAL_AMFLAGS = -Im4 -I.
 
 AM_CFLAGS = $(TIRPC_CFLAGS)
 
+# FreeBSD's <rpc/xdr.h> references bool_t but does not pull in
+# <rpc/types.h> itself (libtirpc on Linux does).  The generated
+# XDR headers include <rpc/xdr.h> directly; force-include
+# <rpc/types.h> for every .c in this subdir so bool_t is in scope.
+if HOST_FREEBSD
+AM_CFLAGS += -include rpc/types.h
+endif
+
 GEN_SOURCES = \
 	ref_cp_xdr.h		\
 	ref_cp_xdr.c		\

--- a/src/probe1_client.c
+++ b/src/probe1_client.c
@@ -34,7 +34,7 @@ static void signal_handler(int sig)
 {
 	TRACE("Received signal %d, initiating shutdown...", sig);
 
-	__atomic_store(&running, &(int){ 0 }, __ATOMIC_SEQ_CST);
+	__atomic_store(&running, &(sig_atomic_t){ 0 }, __ATOMIC_SEQ_CST);
 
 	// Wake up any waiting worker threads
 	wake_worker_threads();
@@ -348,7 +348,7 @@ int main(int argc, char *argv[])
 
 	pthread_sigmask(SIG_UNBLOCK, &mask, NULL);
 
-	__atomic_store(&running, &(int){ 1 }, __ATOMIC_SEQ_CST);
+	__atomic_store(&running, &(sig_atomic_t){ 1 }, __ATOMIC_SEQ_CST);
 
 	// Run the main IO processing loop
 	io_handler_main_loop(&running, rc);


### PR DESCRIPTION
## Summary

17 commits that together let reffs configure and build on FreeBSD 15.
Linux unchanged — all changes are host-gated (\`\$host_os\` in
configure.ac, \`#if defined(__linux__)\` / \`#if defined(__FreeBSD__)\`
in source, or \`HOST_FREEBSD\` automake conditional).

### configure.ac
- libtirpc optional (FreeBSD ships SunRPC in base libc)
- fuse3 pkg-config detection (\`fuse3\` then \`fuse\`)
- liburing default \`auto\` instead of \`yes\`
- HdrHistogram_c optional (not packaged on FreeBSD)
- \`-include rpc/rpc.h\` on FreeBSD so generated XDR headers
  get \`bool_t\` / \`enum auth_stat\` in scope
- \`-DEREMOTEIO=EIO\` / \`-DENODATA=ENOATTR\` shims for glibc-only errnos
- \`-Wno-gnu\` on FreeBSD for liburcu's named-variadic-macro headers
- Strip broken \`-Wl,-rpath\` fragment from FreeBSD rocksdb.pc
- \`-lexecinfo\` on FreeBSD for \`backtrace(3)\`
- \`AC_CHECK_HEADERS([rpc/auth_gss.h])\` — needed separately from
  \`HAVE_GSSAPI_KRB5\` because FreeBSD has GSSAPI but no libtirpc

### source-level gates
- \`lib/include/reffs/log.h\`: portable \`reffs_gettid()\`
  (Linux \`syscall(SYS_gettid)\`, FreeBSD \`pthread_getthreadid_np\`)
- \`lib/include/reffs/log.h\`: \`EREMOTEIO\` fallback to \`EIO\`
  (belt-and-suspenders; also handled via \`-D\`)
- \`lib/include/reffs/network.h\`: explicit \`<netinet/in.h>\` +
  \`<sys/socket.h>\` for \`sockaddr_storage\` visibility
- \`lib/include/reffs/tls.h\`: explicit \`reffs/log.h\` for \`LOG()\`
- \`lib/utils/server.c\`: \`HOST_NAME_MAX\` fallback via \`<sys/param.h>\`
- \`lib/fs/fuse.c\`: \`<fuse.h>\` via pkg-config \`-I\` instead of
  \`<fuse/fuse.h>\` (libfuse2-only path)
- \`lib/fs/Makefile.am\`: skip \`fuse.c\` on FreeBSD (libfuse2 API)
- \`lib/nfs4/server/copy.c\`: Linux FICLONERANGE gated on \`__linux__\`,
  FreeBSD returns NFS4ERR_NOTSUPP; \`loff_t\` typedef to \`off_t\`
- \`lib/nfs4/client/mds_session.c\`: GSS-RPC code gated on
  \`HAVE_GSSAPI_KRB5 && HAVE_RPC_AUTH_GSS_H\` (instead of
  \`HAVE_GSSAPI_KRB5\` alone); mds_session_create/destroy/set_owner
  compile as no-GSS stubs on FreeBSD
- \`lib/rpc/rpc.c\` + \`lib/probe1/probe1_server.c\`: HdrHistogram usage
  gated on \`HAVE_HDR_HISTOGRAM\`
- \`lib/trace/common.c\`: use \`reffs_gettid()\`
- \`src/probe1_client.c\`: \`&(sig_atomic_t){0}\` instead of
  \`&(int){0}\` in \`__atomic_store\` — required on FreeBSD where
  \`sig_atomic_t\` is \`long\`
- Various: gate \`<sys/sysmacros.h>\`, \`<linux/fs.h>\` behind
  \`__linux__\`; add missing \`<stdio.h>\` includes uncovered by
  the \`-include rpc/rpc.h\` chain

## Test plan

- [x] \`./configure && make && make check\` clean on shadow (Linux)
  — no change in output or warnings vs main
- [x] \`./configure && make\` completes on witchie (FreeBSD 15) when
  stacked with #1 and #3 — \`./src/reffsd\` starts and enters main()
- [ ] (future) runtime tests on FreeBSD require the PR 2 completion
  handler port

## Merge order

Middle of a three-branch stack.  Depends on #1 (opaque ring_context)
being in main.  **Textual conflict on merge:** \`src/reffsd.c\` and
\`src/probe1_client.c\` — substrate's \`(sig_atomic_t){0}\` compound
literal touches the same lines PR #1 restructured from
stack-allocated \`rc\` to heap.  Resolution: keep both — the
\`ring_context_alloc()\` lifecycle from PR #1 and the
\`(sig_atomic_t){0}\` compound literal from this PR.

## Commit breakdown

17 commits, each narrowly scoped (configure.ac fragment OR single-file
source gate).  \`git log --oneline\` shows the progression.