### PR TITLE
io: extract net_state bookkeeping (pending_requests, listeners, buffer_state) from handler.c

### DIFF
--- a/lib/include/reffs/io.h
+++ b/lib/include/reffs/io.h
@@ -218,6 +218,13 @@ void io_handler_main_loop(volatile sig_atomic_t *running,
 void io_handler_stop(void);
 void io_handler_signal_shutdown(void);
 
+/*
+ * Backend-agnostic shutdown of lib/io/net_state.c state (request
+ * table, pending buffers).  Backends must call this from their
+ * io_handler_fini after draining in-flight operations.
+ */
+void io_net_state_fini(void);
+
 /* ------------------------------------------------------------------ */
 /* Backend file-I/O ring                                              */
 /* ------------------------------------------------------------------ */

--- a/lib/io/Makefile.am
+++ b/lib/io/Makefile.am
@@ -20,6 +20,7 @@ libreffs_io_la_SOURCES =	\
 	context.c		\
 	handlers.c		\
 	lsnr.c			\
+	net_state.c		\
 	tls.c			\
 	worker.c
 

--- a/lib/io/backend_kqueue.c
+++ b/lib/io/backend_kqueue.c
@@ -510,6 +510,7 @@ int io_handler_init(struct ring_context *rc,
 void io_handler_fini(struct ring_context *rc)
 {
 	kq_teardown(rc);
+	io_net_state_fini();
 }
 
 void io_handler_stop(void) {}
@@ -841,24 +842,6 @@ int io_request_read_op(int fd, struct connection_info *ci,
 /* return errors at runtime until the real implementations land.       */
 /* ------------------------------------------------------------------ */
 
-int io_register_request(struct rpc_trans *rt)
-{
-	(void)rt;
-	return ENOSYS;
-}
-
-int io_unregister_request(uint32_t xid)
-{
-	(void)xid;
-	return ENOSYS;
-}
-
-struct rpc_trans *io_find_request_by_xid(uint32_t xid)
-{
-	(void)xid;
-	return NULL;
-}
-
 int io_rpc_trans_cb(struct rpc_trans *rt)
 {
 	(void)rt;
@@ -894,18 +877,6 @@ void io_heartbeat_update_completions(uint64_t count)
 	(void)count;
 }
 
-void io_add_listener(int fd) { (void)fd; }
-void io_client_fd_register(int fd) { (void)fd; }
-void io_client_fd_unregister(int fd) { (void)fd; }
-void io_check_for_listener_restart(int fd, struct connection_info *ci,
-				   struct ring_context *rc)
-{ (void)fd; (void)ci; (void)rc; }
-bool io_buffer_append(struct buffer_state *bs, const char *data, size_t len)
-{ (void)bs; (void)data; (void)len; return false; }
-struct buffer_state *io_buffer_state_create(int fd)
-{ (void)fd; return NULL; }
-struct buffer_state *io_buffer_state_get(int fd)
-{ (void)fd; return NULL; }
 int io_send_request(struct rpc_trans *rt)
 { (void)rt; return -ENOSYS; }
 int io_schedule_heartbeat(struct ring_context *rc)

--- a/lib/io/handler.c
+++ b/lib/io/handler.c
@@ -49,104 +49,7 @@ int gss_server_cred_init(void);
 void gss_server_cred_fini(void);
 _Bool gss_server_cred_is_available(void);
 
-// Request tracking
-struct rpc_trans *pending_requests[MAX_PENDING_REQUESTS];
-pthread_mutex_t request_mutex = PTHREAD_MUTEX_INITIALIZER;
-
 static time_t last_accept_check;
-
-// Set of listener sockets to monitor
-int listener_fds[MAX_LISTENERS];
-int num_listeners = 0;
-
-//
-// Need to prune out connections that get timed out
-//
-
-// Store buffer states by fd
-struct buffer_state *conn_buffers[MAX_CONNECTIONS];
-
-// Register a new request for tracking
-int io_register_request(struct rpc_trans *rt)
-{
-	pthread_mutex_lock(&request_mutex);
-
-	TRACE("rt=%p xid=0x%08x", (void *)rt, rt->rt_info.ri_xid);
-	// Find an empty slot
-	for (int i = 0; i < MAX_PENDING_REQUESTS; i++) {
-		if (pending_requests[i] == NULL) {
-			TRACE("rt=%p xid=0x%08x", (void *)rt,
-			      rt->rt_info.ri_xid);
-			pending_requests[i] = rt;
-			pthread_mutex_unlock(&request_mutex);
-			return 0;
-		}
-	}
-
-	pthread_mutex_unlock(&request_mutex);
-	return ENOENT;
-}
-
-// Find a request by XID
-struct rpc_trans *io_find_request_by_xid(uint32_t xid)
-{
-	struct rpc_trans *rt = NULL;
-
-	TRACE("xid=0x%08x", xid);
-	pthread_mutex_lock(&request_mutex);
-	for (int i = 0; i < MAX_PENDING_REQUESTS; i++) {
-		if (pending_requests[i] &&
-		    pending_requests[i]->rt_info.ri_xid == xid) {
-			TRACE("rt=%p xid=0x%08x", (void *)pending_requests[i],
-			      xid);
-			rt = pending_requests[i];
-			break;
-		}
-	}
-	pthread_mutex_unlock(&request_mutex);
-
-	return rt;
-}
-
-int io_unregister_request(uint32_t xid)
-{
-	TRACE("xid=0x%08x", xid);
-	pthread_mutex_lock(&request_mutex);
-	for (int i = 0; i < MAX_PENDING_REQUESTS; i++) {
-		if (pending_requests[i] &&
-		    pending_requests[i]->rt_info.ri_xid == xid) {
-			TRACE("rt=%p xid=0x%08x", (void *)pending_requests[i],
-			      xid);
-			pending_requests[i] = NULL;
-			pthread_mutex_unlock(&request_mutex);
-			return 0;
-		}
-	}
-	pthread_mutex_unlock(&request_mutex);
-
-	return ENOENT;
-}
-
-// Register client fd
-void io_client_fd_register(int fd)
-{
-	// In this simplified version, we just track buffer state
-	io_buffer_state_create(fd);
-}
-
-// Unregister client fd
-void io_client_fd_unregister(int fd)
-{
-	struct buffer_state *bs = io_buffer_state_get(fd);
-	if (bs) {
-		free(bs->bs_data);
-		if (bs->bs_record.rs_data) {
-			free(bs->bs_record.rs_data);
-		}
-		free(bs);
-		conn_buffers[fd % MAX_CONNECTIONS] = NULL;
-	}
-}
 
 /*
  * Shutdown eventfd: the signal handler writes to this to produce a
@@ -188,9 +91,6 @@ int io_handler_init(struct ring_context *rc, const char *tls_cert,
 {
 	// Store global reference for callback paths (CB_RECALL etc.)
 	g_network_rc = rc;
-
-	// Initialize pending requests array
-	memset(conn_buffers, 0, sizeof(conn_buffers));
 
 	if (pthread_mutex_init(&rc->rc_mutex, NULL) != 0) {
 		LOG("Failed to initialize ring mutex");
@@ -237,89 +137,6 @@ int io_handler_init(struct ring_context *rc, const char *tls_cert,
 	return 0;
 }
 
-// Create buffer state for a connection
-struct buffer_state *io_buffer_state_create(int fd)
-{
-	struct buffer_state *bs = malloc(sizeof(struct buffer_state));
-	if (!bs)
-		return NULL;
-
-	bs->bs_fd = fd;
-	bs->bs_capacity = BUFFER_SIZE * 2;
-	bs->bs_data = malloc(bs->bs_capacity);
-	bs->bs_filled = 0;
-
-	// Initialize record state
-	bs->bs_record.rs_last_fragment = false;
-	bs->bs_record.rs_fragment_len = 0;
-	bs->bs_record.rs_data = NULL;
-	bs->bs_record.rs_total_len = 0;
-	bs->bs_record.rs_capacity = 0;
-	bs->bs_record.rs_position = 0;
-
-	if (!bs->bs_data) {
-		free(bs);
-		return NULL;
-	}
-
-	int slot = fd % MAX_CONNECTIONS;
-	if (conn_buffers[slot] != NULL) {
-		LOG("io: conn_buffers alias: fd=%d slot=%d already occupied -- "
-		    "increase MAX_CONNECTIONS or use a hash map",
-		    fd, slot);
-		free(bs->bs_data);
-		free(bs);
-		return NULL;
-	}
-	conn_buffers[slot] = bs;
-	return bs;
-}
-
-// Get buffer state for a connection
-struct buffer_state *io_buffer_state_get(int fd)
-{
-	return conn_buffers[fd % MAX_CONNECTIONS];
-}
-
-// Append data to a buffer, resizing if necessary
-bool io_buffer_append(struct buffer_state *bs, const char *data, size_t len)
-{
-	// Avoid integer overflow in capacity calculation
-	if (len > SIZE_MAX / 2 || bs->bs_filled > SIZE_MAX - len) {
-		return false; // Prevent integer overflow
-	}
-
-	// Check if we need to resize
-	if (bs->bs_filled + len > bs->bs_capacity) {
-		// Calculate new capacity, ensuring we allocate enough space
-		size_t min_needed = bs->bs_filled + len;
-		size_t new_capacity = bs->bs_capacity;
-
-		// Double capacity until it's enough
-		while (new_capacity < min_needed) {
-			if (new_capacity > SIZE_MAX / 2) {
-				// Would overflow
-				return false;
-			}
-			new_capacity *= 2;
-		}
-
-		// Perform reallocation
-		char *new_data = realloc(bs->bs_data, new_capacity);
-		if (!new_data)
-			return false;
-
-		bs->bs_data = new_data;
-		bs->bs_capacity = new_capacity;
-	}
-
-	// Append the data after successful reallocation
-	memcpy(bs->bs_data + bs->bs_filled, data, len);
-	bs->bs_filled += len;
-
-	return true;
-}
-
 volatile sig_atomic_t *running_context;
 
 void io_handler_stop(void)
@@ -338,30 +155,6 @@ void io_handler_signal_shutdown(void)
 		uint64_t val = 1;
 		(void)write(shutdown_efd, &val, sizeof(val));
 	}
-}
-
-void io_add_listener(int fd)
-{
-	if (fd > 0)
-		listener_fds[num_listeners++] = fd;
-}
-
-void io_check_for_listener_restart(int fd, struct connection_info *ci,
-				   struct ring_context *rc)
-{
-	for (int i = 0; i < num_listeners; i++) {
-		if (fd == listener_fds[i]) {
-			LOG("Listener socket closed, immediately resubmitting accept");
-			io_request_accept_op(fd, ci, rc);
-			break;
-		}
-	}
-}
-
-int *io_heartbeat_get_listeners(int *num)
-{
-	*num = num_listeners;
-	return listener_fds;
 }
 
 void io_handler_main_loop(volatile sig_atomic_t *running_flag,
@@ -635,29 +428,9 @@ void io_handler_fini(struct ring_context *rc)
 		io_uring_cqe_seen(&rc->rc_ring, cqe);
 	}
 
-	// Cleanup any pending requests
-	TRACE("Cleaning up pending requests...");
-	pthread_mutex_lock(&request_mutex);
-	for (int i = 0; i < MAX_PENDING_REQUESTS; i++) {
-		if (pending_requests[i]) {
-			rpc_protocol_free(pending_requests[i]);
-			pending_requests[i] = NULL;
-		}
-	}
-	pthread_mutex_unlock(&request_mutex);
-
-	// Cleanup connection buffers
-	for (int i = 0; i < MAX_CONNECTIONS; i++) {
-		if (conn_buffers[i]) {
-			if (conn_buffers[i]->bs_data) {
-				free(conn_buffers[i]->bs_data);
-			}
-			if (conn_buffers[i]->bs_record.rs_data) {
-				free(conn_buffers[i]->bs_record.rs_data);
-			}
-			free(conn_buffers[i]);
-		}
-	}
+	// Cleanup shared net_state (pending requests + buffer states)
+	TRACE("Cleaning up net_state...");
+	io_net_state_fini();
 
 	TRACE("Cleaning up remaining active contexts...");
 	io_context_release_active();

--- a/lib/io/net_state.c
+++ b/lib/io/net_state.c
@@ -42,8 +42,8 @@
 /* Request tracking                                                    */
 /* ------------------------------------------------------------------ */
 
-struct rpc_trans *pending_requests[MAX_PENDING_REQUESTS];
-pthread_mutex_t request_mutex = PTHREAD_MUTEX_INITIALIZER;
+static struct rpc_trans *pending_requests[MAX_PENDING_REQUESTS];
+static pthread_mutex_t request_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 int io_register_request(struct rpc_trans *rt)
 {
@@ -107,8 +107,8 @@ int io_unregister_request(uint32_t xid)
 /* Listener registry                                                   */
 /* ------------------------------------------------------------------ */
 
-int listener_fds[MAX_LISTENERS];
-int num_listeners = 0;
+static int listener_fds[MAX_LISTENERS];
+static int num_listeners = 0;
 
 void io_add_listener(int fd)
 {
@@ -138,7 +138,7 @@ int *io_heartbeat_get_listeners(int *num)
 /* Per-fd buffer state                                                 */
 /* ------------------------------------------------------------------ */
 
-struct buffer_state *conn_buffers[MAX_CONNECTIONS];
+static struct buffer_state *conn_buffers[MAX_CONNECTIONS];
 
 void io_client_fd_register(int fd)
 {

--- a/lib/io/net_state.c
+++ b/lib/io/net_state.c
@@ -1,0 +1,264 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Tom Haynes <loghyr@gmail.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Backend-agnostic network-state bookkeeping:
+ *
+ *   - pending_requests[] / request_mutex: in-flight outbound RPC
+ *     tracking keyed by XID, used by the connect completion handler
+ *     to match a CONNECT CQE to the originating io_send_request.
+ *
+ *   - listener_fds[] / num_listeners: server-side listen sockets; the
+ *     listener-restart path uses this to re-arm the accept op when a
+ *     listener socket is closed.
+ *
+ *   - conn_buffers[] / io_buffer_state_*: per-fd accumulating buffers
+ *     for reassembling RPC records across partial TCP reads.
+ *
+ * Extracted from lib/io/handler.c so both the io_uring and kqueue
+ * backends share a single implementation.  The only state this
+ * module owns is bookkeeping; actual I/O submission remains backend-
+ * specific.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h" // IWYU pragma: keep
+#endif
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "reffs/log.h"
+#include "reffs/io.h"
+#include "reffs/rpc.h"
+#include "reffs/trace/io.h"
+
+/* ------------------------------------------------------------------ */
+/* Request tracking                                                    */
+/* ------------------------------------------------------------------ */
+
+struct rpc_trans *pending_requests[MAX_PENDING_REQUESTS];
+pthread_mutex_t request_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+int io_register_request(struct rpc_trans *rt)
+{
+	pthread_mutex_lock(&request_mutex);
+
+	TRACE("rt=%p xid=0x%08x", (void *)rt, rt->rt_info.ri_xid);
+	for (int i = 0; i < MAX_PENDING_REQUESTS; i++) {
+		if (pending_requests[i] == NULL) {
+			TRACE("rt=%p xid=0x%08x", (void *)rt,
+			      rt->rt_info.ri_xid);
+			pending_requests[i] = rt;
+			pthread_mutex_unlock(&request_mutex);
+			return 0;
+		}
+	}
+
+	pthread_mutex_unlock(&request_mutex);
+	return ENOENT;
+}
+
+struct rpc_trans *io_find_request_by_xid(uint32_t xid)
+{
+	struct rpc_trans *rt = NULL;
+
+	TRACE("xid=0x%08x", xid);
+	pthread_mutex_lock(&request_mutex);
+	for (int i = 0; i < MAX_PENDING_REQUESTS; i++) {
+		if (pending_requests[i] &&
+		    pending_requests[i]->rt_info.ri_xid == xid) {
+			TRACE("rt=%p xid=0x%08x", (void *)pending_requests[i],
+			      xid);
+			rt = pending_requests[i];
+			break;
+		}
+	}
+	pthread_mutex_unlock(&request_mutex);
+
+	return rt;
+}
+
+int io_unregister_request(uint32_t xid)
+{
+	TRACE("xid=0x%08x", xid);
+	pthread_mutex_lock(&request_mutex);
+	for (int i = 0; i < MAX_PENDING_REQUESTS; i++) {
+		if (pending_requests[i] &&
+		    pending_requests[i]->rt_info.ri_xid == xid) {
+			TRACE("rt=%p xid=0x%08x", (void *)pending_requests[i],
+			      xid);
+			pending_requests[i] = NULL;
+			pthread_mutex_unlock(&request_mutex);
+			return 0;
+		}
+	}
+	pthread_mutex_unlock(&request_mutex);
+
+	return ENOENT;
+}
+
+/* ------------------------------------------------------------------ */
+/* Listener registry                                                   */
+/* ------------------------------------------------------------------ */
+
+int listener_fds[MAX_LISTENERS];
+int num_listeners = 0;
+
+void io_add_listener(int fd)
+{
+	if (fd > 0)
+		listener_fds[num_listeners++] = fd;
+}
+
+void io_check_for_listener_restart(int fd, struct connection_info *ci,
+				   struct ring_context *rc)
+{
+	for (int i = 0; i < num_listeners; i++) {
+		if (fd == listener_fds[i]) {
+			LOG("Listener socket closed, immediately resubmitting accept");
+			io_request_accept_op(fd, ci, rc);
+			break;
+		}
+	}
+}
+
+int *io_heartbeat_get_listeners(int *num)
+{
+	*num = num_listeners;
+	return listener_fds;
+}
+
+/* ------------------------------------------------------------------ */
+/* Per-fd buffer state                                                 */
+/* ------------------------------------------------------------------ */
+
+struct buffer_state *conn_buffers[MAX_CONNECTIONS];
+
+void io_client_fd_register(int fd)
+{
+	io_buffer_state_create(fd);
+}
+
+void io_client_fd_unregister(int fd)
+{
+	struct buffer_state *bs = io_buffer_state_get(fd);
+	if (bs) {
+		free(bs->bs_data);
+		if (bs->bs_record.rs_data) {
+			free(bs->bs_record.rs_data);
+		}
+		free(bs);
+		conn_buffers[fd % MAX_CONNECTIONS] = NULL;
+	}
+}
+
+struct buffer_state *io_buffer_state_create(int fd)
+{
+	struct buffer_state *bs = malloc(sizeof(struct buffer_state));
+	if (!bs)
+		return NULL;
+
+	bs->bs_fd = fd;
+	bs->bs_capacity = BUFFER_SIZE * 2;
+	bs->bs_data = malloc(bs->bs_capacity);
+	bs->bs_filled = 0;
+
+	bs->bs_record.rs_last_fragment = false;
+	bs->bs_record.rs_fragment_len = 0;
+	bs->bs_record.rs_data = NULL;
+	bs->bs_record.rs_total_len = 0;
+	bs->bs_record.rs_capacity = 0;
+	bs->bs_record.rs_position = 0;
+
+	if (!bs->bs_data) {
+		free(bs);
+		return NULL;
+	}
+
+	int slot = fd % MAX_CONNECTIONS;
+	if (conn_buffers[slot] != NULL) {
+		LOG("io: conn_buffers alias: fd=%d slot=%d already occupied -- "
+		    "increase MAX_CONNECTIONS or use a hash map",
+		    fd, slot);
+		free(bs->bs_data);
+		free(bs);
+		return NULL;
+	}
+	conn_buffers[slot] = bs;
+	return bs;
+}
+
+struct buffer_state *io_buffer_state_get(int fd)
+{
+	return conn_buffers[fd % MAX_CONNECTIONS];
+}
+
+bool io_buffer_append(struct buffer_state *bs, const char *data, size_t len)
+{
+	if (len > SIZE_MAX / 2 || bs->bs_filled > SIZE_MAX - len) {
+		return false;
+	}
+
+	if (bs->bs_filled + len > bs->bs_capacity) {
+		size_t min_needed = bs->bs_filled + len;
+		size_t new_capacity = bs->bs_capacity;
+
+		while (new_capacity < min_needed) {
+			if (new_capacity > SIZE_MAX / 2) {
+				return false;
+			}
+			new_capacity *= 2;
+		}
+
+		char *new_data = realloc(bs->bs_data, new_capacity);
+		if (!new_data)
+			return false;
+
+		bs->bs_data = new_data;
+		bs->bs_capacity = new_capacity;
+	}
+
+	memcpy(bs->bs_data + bs->bs_filled, data, len);
+	bs->bs_filled += len;
+
+	return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Shutdown cleanup                                                    */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Free everything held by this module.  Called from each backend's
+ * io_handler_fini after in-flight operations have drained.
+ */
+void io_net_state_fini(void)
+{
+	pthread_mutex_lock(&request_mutex);
+	for (int i = 0; i < MAX_PENDING_REQUESTS; i++) {
+		if (pending_requests[i]) {
+			rpc_protocol_free(pending_requests[i]);
+			pending_requests[i] = NULL;
+		}
+	}
+	pthread_mutex_unlock(&request_mutex);
+
+	for (int i = 0; i < MAX_CONNECTIONS; i++) {
+		if (conn_buffers[i]) {
+			if (conn_buffers[i]->bs_data) {
+				free(conn_buffers[i]->bs_data);
+			}
+			if (conn_buffers[i]->bs_record.rs_data) {
+				free(conn_buffers[i]->bs_record.rs_data);
+			}
+			free(conn_buffers[i]);
+			conn_buffers[i] = NULL;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Third in the kqueue-backend stub-replacement series.  Moves three
backend-agnostic global tables out of \`lib/io/handler.c\`
(liburing-only) into a new \`lib/io/net_state.c\` compiled on both
backends:

- **pending_requests[] / request_mutex**: in-flight outbound RPC
  tracking keyed by XID.
- **listener_fds[] / num_listeners**: server-side listen sockets;
  used by \`io_check_for_listener_restart\` to re-arm the accept op.
- **conn_buffers[] / io_buffer_state_***: per-fd accumulating buffers
  for reassembling RPC records across partial TCP reads, plus
  \`io_client_fd_register\` / \`unregister\`.

Adds a new public \`io_net_state_fini()\` for shutdown cleanup,
replacing the inline cleanup that used to live in \`io_handler_fini\`.
Each backend calls it from its \`io_handler_fini\`.

Drops the redundant \`memset(conn_buffers, 0, sizeof(conn_buffers))\`
from \`io_handler_init\` — static arrays are BSS-zero by C standard.

Removes nine stubs from \`backend_kqueue.c\`.

On FreeBSD the kqueue backend now has real request-table /
listener / buffer-state bookkeeping instead of silently dropping
every call.  On Linux, pure code move — no behavioral change.

## Reviewer pass

Ran c-protocol-review-prompts reviewer role against the extraction
commit.  **0 regressions.**  Two NOTEs addressed in followup commit:

- Tables declared \`static\` — tightens module boundary, no semantic change.
- Cleanup loop NULLs \`conn_buffers[i]\` after free (safety improvement
  vs. pre-extraction inline cleanup).

## Test plan

- [x] \`make && make check\` clean on Linux (dreamer) — 3 io tests pass
- [x] \`gmake && gmake check\` clean on FreeBSD (witchie) — 2 io tests
- [x] \`reffsd --help\` still runs on FreeBSD

## Remaining FreeBSD stubs (after this PR)

\`backend_kqueue.c\` still stubs: \`io_handle_read\`, \`io_handle_write\`,
\`io_rpc_trans_cb\`, \`io_request_write_op\`, \`io_request_read_op\`,
\`io_send_request\`, \`io_schedule_heartbeat\`, and the heartbeat
accounting.  PR #7 will port the read/write submission path — that's
the real FreeBSD I/O work, not another mechanical extraction.