### PR TITLE
io/backend_kqueue: guard NULL ci in io_request_accept_op (PR #7 follow-up)

### DIFF
--- a/lib/io/backend_kqueue.c
+++ b/lib/io/backend_kqueue.c
@@ -557,7 +557,8 @@ int io_request_accept_op(int fd, struct connection_info *ci,
 	if (!ic)
 		return -ENOMEM;
 
-	ic->ic_ci = *ci;
+	if (ci)
+		ic->ic_ci = *ci;
 
 	struct kevent ke;
 


### PR DESCRIPTION
One-line hotfix. Discovered running the PR #7 smoke test on witchie: reffsd segfaults in memcpy before the main loop starts because `io_request_accept_op` on kqueue unconditionally copies `*ci` -- and `main()` calls it with `ci=NULL` for the initial listener arming.

The liburing side already guards with `if (ci)`; match that.

Backtrace:
```
#0 memcpy ()
#1 io_request_accept_op (fd=10, ci=0x0, rc=...) at backend_kqueue.c:560
#2 main (argc=7, argv=...) at reffsd.c:620
```

Latent since PR #3 (kqueue skeleton) -- only surfaced now because PR #7 made the full accept path reachable.

Test plan: rebuild on witchie, rerun `./src/reffsd -b ram -S /var/lib/reffs -c 1`, confirm no crash.