### PR TITLE
.claude: lessons from FreeBSD I/O backend port

### DIFF
--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -593,6 +593,197 @@ deferral, record it as `DEFERRED`, and do not block the commit.
 
 ---
 
+## 17. Backend port / reachability-change review
+
+reffs maintains two I/O backends (liburing on Linux, kqueue+aio on
+FreeBSD) and a shared-handlers layer (`lib/io/handlers.c`,
+`lib/io/conn_info.c`, `lib/io/net_state.c`).  Commits that change
+reachability across this boundary -- extraction refactors, stub
+removals, new backend primitives, platform probes -- have
+bug-hazard profiles that standard review misses.  This section
+applies when the CHANGE touches:
+
+- `lib/io/backend_kqueue.c` or `lib/io/backend.c`
+- `lib/io/handlers.c`, `lib/io/conn_info.c`, `lib/io/net_state.c`
+- Any `Makefile.am` that changes which `.c` is compiled per backend
+- `io_request_{read,write,accept,connect}_op` signatures
+- `io_handle_{read,write,accept,connect}` signatures
+- `io_resubmit_{read,write}` signatures
+- Removal of `__attribute__((unused))` or `static` that was hiding code
+
+Load the external pattern `patterns/reachability-change.md` from
+`c-protocol-review-prompts` if available; fall back to the checks
+below.
+
+### 17a. Bidirectional reachability gate -- BLOCKER [LATENT-BUG-REACHED]
+
+Every commit has a forward reachability question: is the new code
+reachable?  Backend ports have an equally important backward one:
+does the new code make old code reachable for the first time?
+
+**Concrete reffs example.** The kqueue backend skeleton
+(`backend_kqueue.c`, merged at PR #3) contained:
+
+```c
+int io_request_accept_op(int fd, struct connection_info *ci,
+                         struct ring_context *rc)
+{
+    struct io_context *ic = io_context_create(OP_TYPE_ACCEPT, fd, NULL, 0);
+    if (!ic) return -ENOMEM;
+
+    ic->ic_ci = *ci;      /* <-- unconditional deref */
+```
+
+The liburing sibling at `lib/io/accept.c:86` guards the copy with
+`if (ci) copy_connection_info(...)`.  The kqueue version did not.
+The bug sat latent for weeks because earlier layers stubbed out the
+accept path entirely.  PR #7 finished wiring network handlers; PR
+#7's own code was clean, but `main()` calls `io_request_accept_op`
+with `ci=NULL` for the initial listener arming -- a crash at
+memcpy on first run on FreeBSD.
+
+If PR #7's reviewer had asked "what code does this newly reach?"
+and re-checked `io_request_accept_op` against its callers, the bug
+would have been caught pre-merge.  Instead it surfaced only during
+smoke testing (commit `6b1734f47be3`).
+
+**Review technique.** For any extraction or port commit, list the
+newly-reachable functions explicitly at the top of the review:
+
+```
+NEWLY-REACHABLE CODE (in scope for this review):
+  - lib/io/backend_kqueue.c:io_request_accept_op(fd, ci, rc) -- called from main()
+  - lib/io/backend_kqueue.c:kqueue_arm_heartbeat_timer(rc, ic, ns)
+```
+
+Then audit each as if it were new code: NULL guards, error paths,
+edge inputs.
+
+### 17b. Cross-backend invariant audit -- BLOCKER [INVARIANT-BACKEND-MISMATCH]
+
+Shared code assumes invariants that are trivially true on one backend
+and load-bearing on another.  The per-fd write-serialization gate
+in `lib/io/conn_info.c:io_conn_write_try_start` is the canonical
+example:
+
+| Invariant | io_uring | kqueue |
+|---|---|---|
+| Only one write in flight per fd | Kernel linearizes concurrent SQEs | `EV_ADD\|EV_ONESHOT` *replaces* existing knote's udata |
+| Error delivered as -errno | `cqe->res` | `write(2)` ret + errno, needs translation |
+| ic ownership transits kernel boundary | SQE submit | kevent ADD |
+
+A gate that works by convention on io_uring is **correctness-critical
+and silent-failure-prone on kqueue**.  When `io_do_tls` submits an
+encrypted-data ic via `io_request_write_op` *outside* the gate (see
+`lib/io/handlers.c:io_do_tls`), the sibling normal writer can
+overwrite its knote on kqueue, orphaning the TLS ic.  This must be
+called out as a BLOCKER for any PR that enables TLS on FreeBSD.
+
+**Review technique.** For each invariant the shared code assumes,
+open both backend files side by side and verify the primitive
+semantics match.  Record in the review output:
+
+```
+CROSS-BACKEND INVARIANT CHECK:
+  Invariant: at most one in-flight write per fd
+  io_uring primitive: io_uring_prep_write + io_uring_submit (kernel-linearized)
+  kqueue primitive: EV_ADD|EV_ONESHOT EVFILT_WRITE (REPLACES on duplicate)
+  Verdict: gate required on kqueue; documented as such; TLS path exempt (deferred).
+```
+
+### 17c. Calling convention at backend/shared boundary -- BLOCKER [CONVENTION-MISMATCH]
+
+Shared handlers (`io_handle_{read,write,accept,connect}`) expect
+**cqe->res semantics**: non-negative byte count or fd, or negative
+errno.  Backend-specific dispatchers must translate to this
+convention before calling the handler.
+
+**Concrete reffs example.** The kqueue `accept_and_dispatch` originally
+passed `accept4(2)`'s raw -1 to `io_handle_accept`, which reported
+`strerror(1)` ("Operation not permitted") regardless of the real
+errno.  Fix: translate `-1` to `-errno` before dispatch.
+
+Review every `*_and_dispatch` function in `backend_kqueue.c`:
+
+- Does `accept_and_dispatch` pass `-errno` (not raw -1)?
+- Does `connect_and_dispatch` pass `-SO_ERROR` (not raw connect result)?
+- Does `read_and_dispatch` pass `nread` (byte count) or `-errno` (not raw -1)?
+- Does `write_and_dispatch` pass `nwritten` (byte count) or `-errno`?
+
+### 17d. Stub-removal atomicity -- BLOCKER [SPLIT-STUB-REMOVAL]
+
+When a `-ENOSYS` stub is replaced by a real implementation, every
+caller that was masking the absence must be updated in the same
+commit.  Splitting produces bisect traps where commit N builds with
+a dead stub, commit N+1 builds with an active caller, and commit N+1
+regresses by activating broken code.
+
+Review: grep for every callsite of the stub before approving the
+stub-removal commit.  If any callers are not updated in the same
+commit, ask the author to either fold them in or extend the stub
+removal to the commit that activates the callers.
+
+### 17e. Shared-file extraction must be byte-identical -- BEHAVIOR DELTA
+
+A commit that moves a function from `lib/io/write.c` to
+`lib/io/handlers.c` claiming "pure code move" is a BEHAVIOR DELTA if
+anything else changed.  Drive-by changes hidden in extraction
+commits:
+
+- NULL-guards added or removed
+- Lock scope altered
+- Free / destroy added on an error path
+- Trace or log statement added
+
+These may be improvements, but they are **not** pure moves and must
+be called out.  Either split into a follow-up commit or call them
+out in the commit message body.
+
+**Review technique.** `git show <commit> -- <moved-file>` and
+`git show <commit> -- <new-file>` should produce one-for-one
+deletions and additions.  If any added line lacks a matching
+deletion (or vice versa), that's a BEHAVIOR DELTA.
+
+### 17f. Smoke-run evidence for reachability changes -- BLOCKER [NO-SMOKE]
+
+Static review does not catch runtime-only bugs in newly-reachable
+code (NULL at rarely-reached callsite, calling-convention
+mismatches, buffer-offset-ignored).  For backend ports, platform
+probes, and extractions that activate stubbed code, a smoke run is a
+review step, not a handoff step.
+
+Minimum smoke for a reffs backend port (see `docs/freebsd-smoke.md`):
+
+1. `reffsd` starts, binds listeners, enters main loop on the new
+   target.
+2. NFSv4 mount from a Linux (or localhost) client succeeds.
+3. `dd if=/dev/urandom of=/mnt/nfs/x bs=1M count=16 conv=fsync` +
+   `sha256sum` round-trip matches.
+4. Two concurrent mounts writing to separate files produce distinct,
+   correct sha256 hashes (exercises the per-fd write gate).
+5. Client disconnect mid-write does not leak io_contexts; `pkill
+   reffsd` shuts down cleanly.
+
+A reviewer who signs off a backend-port commit without smoke evidence
+is signing off the design, not the implementation.  Require a log
+excerpt, sha256 comparison, and clean-shutdown observation in the
+review output.
+
+### 17g. Sibling patterns to verify
+
+- `conn_info.c` write gate is held on all normal-write paths; any
+  direct caller of `io_request_write_op` outside `rpc_trans_writer`
+  must be audited (TLS-data submission in `io_do_tls` is the known
+  gate-bypassing caller; others should not exist).
+- `io_context_destroy` takes `context_mutex` and `conn_mutex` but
+  NOT `rc_mutex`.  Any new caller that holds `rc_mutex` while
+  calling destroy is a lock-order BLOCKER.
+- `io_conn_unregister` drops `conn_mutex` before draining
+  `ci_write_pending_head` for exactly this reason -- do not "fix"
+  this apparent lock-scope narrowing.
+
+---
+
 ## Output format
 
 ```

--- a/.claude/patterns/backend-extraction.md
+++ b/.claude/patterns/backend-extraction.md
@@ -1,0 +1,293 @@
+# Backend Extraction Pattern (reffs)
+
+Load this file when CHANGE categories involve:
+
+- `lib/io/backend_kqueue.c` and its `lib/io/backend.c` sibling.
+- Moving code between `lib/io/handlers.c` / `lib/io/conn_info.c` /
+  `lib/io/net_state.c` (shared) and the backend-specific files.
+- Adding or removing stubs on the inactive backend.
+- Changes to `lib/io/Makefile.am` conditional compilation
+  (`if IO_BACKEND_LIBURING` / `if IO_BACKEND_KQUEUE`).
+
+This pattern codifies the extraction methodology used in PRs #4-#7
+of the FreeBSD port (conn_info extraction, handlers extraction,
+net_state extraction, read/write handler + resubmit-primitive
+split).  Future backend work (macOS thread-pool backend, PR #8 TLS
+on kqueue) follows the same pattern.
+
+---
+
+## 1. The reffs Backend Architecture
+
+The I/O layer has three compilation strata:
+
+1. **Always-compiled shared code** (`Makefile.am` `libreffs_io_la_SOURCES` unconditional):
+   - `conn_info.c` -- per-fd hash, connection state machine,
+     write-serialization gate
+   - `handlers.c` -- completion handlers (`io_handle_read/write/accept/connect`),
+     TLS state machine, RPC record marker reassembly,
+     `rpc_trans_writer` orchestration, `io_rpc_trans_cb`,
+     `io_do_tls`
+   - `net_state.c` -- pending request table, listener registry,
+     per-fd buffer state
+   - `context.c` -- `io_context` lifecycle, hash registry
+   - `lsnr.c` -- IPv4/IPv6 listen socket setup
+   - `tls.c` -- OpenSSL server context init (shared but guarded
+     by tls_available)
+   - `worker.c` -- worker thread pool
+
+2. **liburing-only** (`Makefile.am` `if IO_BACKEND_LIBURING`):
+   - `accept.c`, `backend.c`, `connect.c`, `handler.c`,
+     `heartbeat.c`, `read.c`, `write.c`
+
+3. **kqueue-only** (`Makefile.am` `if IO_BACKEND_KQUEUE`):
+   - `backend_kqueue.c` (single file; ~1260 lines)
+
+The backend interface is **compile-time-selected same-named
+functions**, not a runtime vtable.  Each backend provides
+implementations of:
+
+- `io_request_{read,write,accept,connect}_op` -- allocate ic,
+  submit fresh I/O
+- `io_resubmit_{read,write}` -- reuse existing ic, submit next chunk
+- `io_schedule_heartbeat`, `io_heartbeat_*` -- timer-driven watchdog
+- `io_handler_init`, `io_handler_main_loop`, `io_handler_fini`,
+  `io_handler_stop`, `io_handler_signal_shutdown`
+- `io_backend_init` / `io_backend_main_loop` / `io_backend_fini`
+  (file I/O, separate ring from network)
+- `io_send_request` (outbound RPC; `-ENOSYS` stub on kqueue today)
+
+Shared code in `handlers.c` / `conn_info.c` calls these via normal
+function calls; the linker resolves to whichever backend's `.o`
+is in the build.
+
+---
+
+## 2. The Extraction Workflow
+
+When a function is backend-agnostic but currently lives in a
+backend-specific file, extraction follows this sequence:
+
+### Step A: Identify the backend dependencies
+
+Grep for `io_uring_`, `liburing`, `<linux/`, `<sys/eventfd.h>`,
+`<sys/signalfd.h>` in the function body.  If any exist, the function
+is not directly extractable; see §3 below.
+
+### Step B: Determine whether siblings need a primitive
+
+If the function calls a `static` helper that IS backend-specific
+(e.g., `rpc_trans_writer`'s inline `io_uring_prep_write`), the
+helper must become a public primitive before the function can be
+extracted.  See §4 for the primitive-introduction pattern.
+
+### Step C: Move the function
+
+Cut from backend-specific file, paste into `handlers.c` (or
+`conn_info.c` / `net_state.c` as appropriate).  Include set in
+destination file must include every header the moved code needs.
+Delete the definition from the source file; don't leave behind an
+extern declaration unless the source file still calls the function.
+
+### Step D: Remove matching stubs
+
+The inactive backend (at the time, typically kqueue) often had a
+`-ENOSYS` or no-op stub for the now-shared function.  Delete that
+stub in the **same commit** as the extraction.  Otherwise the build
+breaks with a duplicate-symbol linker error.
+
+### Step E: Audit for orphan callers
+
+`git grep` for the moved function's name.  Every remaining caller
+either passes through the public API (fine) or still references a
+file-scope static from the source file (broken -- fix).
+
+### Step F: Commit as one atomic change
+
+The extraction + stub removal is a single commit.  No bisect traps:
+before this commit, inactive backend has stub; after this commit,
+both backends have the shared implementation.  Commit messages cite
+"pure code move" only if the move truly is byte-identical; otherwise
+call out the BEHAVIOR DELTA explicitly.
+
+---
+
+## 3. Function Depends on Backend Primitive
+
+If the function you want to extract uses `io_uring_prep_write` or
+`kevent(...)` directly, introduce a backend primitive first.  Then
+extract.  This is the pattern `rpc_trans_writer` followed in PR #7:
+
+### Before extraction
+
+```c
+/* lib/io/write.c -- io_uring-only */
+static int rpc_trans_writer(struct io_context *ic, struct ring_context *rc)
+{
+    /* ... gate claim, TLS dispatch, chunk math ... */
+
+    /* direct io_uring calls: */
+    sqe = io_uring_get_sqe(&rc->rc_ring);
+    io_uring_prep_write(sqe, fd, buf, chunk_size, 0);
+    io_uring_submit(&rc->rc_ring);
+    /* ... */
+}
+```
+
+### Step 1: Extract the backend primitive
+
+```c
+/* lib/io/write.c -- io_uring-only, new public function */
+int io_resubmit_write(struct io_context *ic, struct ring_context *rc)
+{
+    /* extracted from rpc_trans_writer: get_sqe / prep_write / submit */
+}
+
+/* lib/io/backend_kqueue.c -- stub, later real */
+int io_resubmit_write(struct io_context *ic, struct ring_context *rc)
+{
+    (void)ic; (void)rc;
+    return -ENOSYS;
+}
+```
+
+Commit 1: refactor rpc_trans_writer to use the primitive.  Pure
+refactor on the active backend; inactive backend's stub satisfies
+the linker but the path is still unreachable (no caller yet).
+
+### Step 2: Extract rpc_trans_writer
+
+Now that `rpc_trans_writer` calls `io_resubmit_write` instead of
+inline io_uring, it's backend-agnostic.  Move it to `handlers.c`.
+
+### Step 3: Implement primitive on inactive backend
+
+Commit 3: replace the `-ENOSYS` stub with a real implementation
+using the inactive backend's primitives.  For kqueue, that's
+`kevent(EV_ADD | EV_ONESHOT, EVFILT_WRITE, ...)`.
+
+**Why three commits instead of one:** each commit builds cleanly on
+both backends and leaves the active backend's behavior unchanged.
+If a regression slips in, `git bisect` can locate which of the three
+steps introduced it.
+
+---
+
+## 4. Stub Contracts
+
+Stubs exist only to satisfy the linker until the real implementation
+lands.  Their contract:
+
+- **Return `-ENOSYS`** for operations that return an int.  Never
+  return `0` (success) or `1` -- silent success hides the missing
+  implementation.
+- **Return `NULL`** for pointer-returning operations, matching
+  allocation-failure semantics.
+- **Log once at `LOG` level** when the stub is called.  The log
+  line should say the backend, the function name, and what PR
+  will provide the real implementation.
+- **Do not call `io_context_destroy`** on ics passed in.  The
+  caller owns lifecycle; stubs should not destroy on the
+  caller's behalf without documentation.
+
+**Exception:** stubs for completion handlers (`io_handle_*`)
+typically DO destroy the ic, because the handler-chain contract is
+"handler takes ownership."  A stub `io_handle_read` must
+`io_context_destroy(ic)` + return `-ENOSYS` to match the real
+handler's contract.
+
+---
+
+## 5. Precondition Documentation
+
+When a shared function has behavior that's safe on one backend due
+to a structural precondition that doesn't hold on the other,
+document the precondition in the function's header comment and in
+the commit message.
+
+**Concrete reffs example.**  `io_do_tls` in `handlers.c` submits via
+`io_request_write_op` outside the per-fd write gate.  On io_uring,
+this is safe because the kernel linearizes concurrent writes.  On
+kqueue, `EV_ADD | EV_ONESHOT` replaces the knote udata, orphaning a
+prior writer.  So on FreeBSD PR #7, `io_do_tls` is unreachable
+because `reffs_server_ssl_ctx` is never initialized -- the TLS
+branch in `rpc_trans_writer` is dead.
+
+The precondition is documented at `handlers.c:io_do_tls` header:
+
+```c
+/*
+ * Unreachable on FreeBSD PR #7 because io_tls_init_server_context is
+ * not called from the kqueue io_handler_init -- ci->ci_ssl is always
+ * NULL.  When PR #8 ports TLS, the io_request_write_op call at the
+ * bottom must be adjusted to honor the per-fd write gate (otherwise
+ * the subsequent writer's EVFILT_WRITE registration silently replaces
+ * this one's on kqueue).  See PR #7 addendum B2 for the analysis.
+ */
+```
+
+and in the commit message body:
+
+> FreeBSD PR #7 precondition: the TLS branch in rpc_trans_writer
+> (ci->ci_ssl && ci->ci_tls_enabled) is unreachable because
+> io_tls_init_server_context is not called from the kqueue
+> io_handler_init.  PR #8 will port TLS and must address the
+> EVFILT_WRITE collision that arises when io_do_tls submits outside
+> the write gate.
+
+**Review technique.**  When the commit message says "unreachable on
+X because Y," verify Y in the code.  If Y is also the preconditions
+for some *other* unreachability, you have a single point of failure
+that the PR removing Y must address.  Track it as a blocker for that
+future PR.
+
+---
+
+## 6. Smoke Evidence for Extraction Commits
+
+For every extraction that activates code on a backend, attach smoke
+evidence to the review:
+
+1. **Build on both backends.**  `make -j4` on dreamer (Linux) and
+   `gmake -j4` on witchie (FreeBSD).  Zero errors, zero new warnings.
+2. **Tests pass on both.**  `make check` on dreamer (all io tests
+   pass); `gmake check` on witchie (io tests pass, liburing-only tests
+   like `tls_write_count_test` correctly gated with `IO_BACKEND_LIBURING`).
+3. **reffsd starts on the activated backend.**  `./src/reffsd -b
+   ram -S /var/lib/reffs -c 1` on witchie enters main loop, listeners
+   on port 2049 appear in `sockstat`.
+4. **Smoke I/O on the activated backend.**  For backend ports:
+   `mount -t nfs -o nfsv4 localhost:/ /mnt/test && dd if=/dev/urandom
+   of=/mnt/test/x bs=1M count=16 conv=sync && sha256sum /mnt/test/x`
+   matches read-back.
+
+The smoke evidence goes in the commit message body or the PR
+description.  A reviewer who approves an extraction commit without
+smoke evidence on the activated backend is signing off an idea, not
+an implementation.
+
+---
+
+## 7. Checklist
+
+Before approving an extraction / backend-port commit:
+
+1. **Forward reachability:** new code runs for the described workload.
+2. **Backward reachability:** every function this newly reaches is
+   re-reviewed (NULL guards, edge inputs, error paths).  List them
+   explicitly in the review output.
+3. **Cross-backend invariants verified:** the shared code's
+   assumptions hold on both backends' primitives.  Called out any
+   invariant that only holds due to a structural precondition.
+4. **Calling conventions audited:** backend dispatchers translate
+   `-1 + errno` / `SO_ERROR` / `cqe->res` uniformly before calling
+   shared handlers.
+5. **Stub removal atomic with extraction:** no bisect trap; both
+   backends build after every commit in the series.
+6. **Move is byte-identical or BEHAVIOR DELTA called out:**
+   drive-by changes split or documented.
+7. **Preconditions documented:** any "safe because X is never
+   true" note is verified and recorded as a blocker for the PR that
+   makes X true.
+8. **Smoke evidence attached:** log + sha256 + clean shutdown on
+   the activated backend.


### PR DESCRIPTION
Add section 17 to `.claude/agents/review.md` covering backend-port and reachability-change reviews, plus a new reffs-specific `.claude/patterns/backend-extraction.md`.

## Motivation

PRs #4-#9 (FreeBSD I/O backend port) exposed three bug classes that standard `/review` missed and one methodology gap:

- **Latent bugs becoming reachable**: accept-NULL deref sat in `backend_kqueue.c` since PR #3, crashed on first witchie smoke run because PR #7 made the path reachable.
- **Cross-backend invariant mismatches**: per-fd write gate trivially holds on io_uring (kernel linearizes), critical-and-silent-on-failure on kqueue (`EV_ADD|EV_ONESHOT` replaces knote udata).
- **Runtime-only bugs missed by unit tests**: 3 BLOCKERs in PR #7 commits 5-6 (NULL read buffer, write-offset-ignored, UAF on EAGAIN-fail).
- **Plan review workflow wasn't documented**: plan-level review for PR #7 caught 3 BLOCKERs + 5 WARNINGs before coding started.

## Changes

- `.claude/agents/review.md`: new section 17 "Backend port / reachability-change review" with subsections 17a-17g covering:
  - Bidirectional reachability gate (list NEWLY-REACHABLE CODE)
  - Cross-backend invariant audit (side-by-side primitive table)
  - Calling convention at backend boundary (cqe->res semantics)
  - Stub-removal atomicity (no bisect traps)
  - Byte-identical extraction discipline (BEHAVIOR DELTA otherwise)
  - Smoke-run evidence required (minimum from `docs/freebsd-smoke.md`)
  - Sibling patterns (write gate coverage, destroy lock order)
- `.claude/patterns/backend-extraction.md` (new, ~280 lines): reffs-specific backend architecture, extraction workflow (three-commit pattern for primitive introduction), stub contracts, precondition documentation, smoke evidence checklist.

## Companion PR

External repo `c-protocol-review-prompts` has a companion PR: https://github.com/loghyr/c-protocol-review-prompts/pull/1 that adds the general `patterns/reachability-change.md` pattern (backend-agnostic), bidirectional gate to `review-core.md`, plan-review workflow to `roles.md`, and smoke-run supplement to `/c-review` slash command.

The two land independently.  The reffs-local change is useful without the external one (falls back to the checks inlined in section 17), and the external pattern is useful without the reffs-local change (it's backend-agnostic).

## Testing

No code changes — docs / agent-config only.  No CI impact.