### PR TITLE
fs/fuse: pass flags arg to filler() for libfuse3 API

### DIFF
--- a/lib/fs/fuse.c
+++ b/lib/fs/fuse.c
@@ -146,14 +146,29 @@ int reffs_fuse_readdir(const char *path, void *buffer, fuse_fill_dir_t filler,
 	if (ret)
 		return ret;
 
+	/*
+	 * libfuse2 fuse_fill_dir_t takes (buf, name, stat, off);
+	 * libfuse3 added a fifth enum fuse_fill_dir_flags argument.
+	 * configure.ac probes fuse3 before fuse, so either is possible
+	 * depending on what's installed; gate on FUSE_MAJOR_VERSION
+	 * (defined in fuse_common.h since both 2.x and 3.x).
+	 */
+#if FUSE_MAJOR_VERSION >= 3
+#define REFFS_FUSE_FILL(buf, name, stbuf, off) \
+	filler((buf), (name), (stbuf), (off), 0)
+#else
+#define REFFS_FUSE_FILL(buf, name, stbuf, off) \
+	filler((buf), (name), (stbuf), (off))
+#endif
+
 	if (offset == 0) {
 		fill_stat(&st, nm->nm_dirent->rd_inode);
-		filler(buffer, ".", &st, ++offset);
+		REFFS_FUSE_FILL(buffer, ".", &st, ++offset);
 		if (nm->nm_dirent->rd_parent)
 			fill_stat(&st, nm->nm_dirent->rd_parent->rd_inode);
 		else
 			fill_stat(&st, nm->nm_dirent->rd_inode);
-		filler(buffer, "..", &st, ++offset);
+		REFFS_FUSE_FILL(buffer, "..", &st, ++offset);
 	}
 
 	rcu_read_lock();
@@ -162,10 +177,12 @@ int reffs_fuse_readdir(const char *path, void *buffer, fuse_fill_dir_t filler,
 		if (cur++ < offset)
 			continue;
 		fill_stat(&st, rd->rd_inode);
-		ret = filler(buffer, rd->rd_name, &st, cur);
+		ret = REFFS_FUSE_FILL(buffer, rd->rd_name, &st, cur);
 		if (ret)
 			break;
 	}
+
+#undef REFFS_FUSE_FILL
 	rcu_read_unlock();
 
 	name_match_free(nm);


### PR DESCRIPTION
Build failure on Linux main — libfuse3 `fuse_fill_dir_t` gained a 5th `enum fuse_fill_dir_flags` argument.  `lib/fs/fuse.c` declares `FUSE_USE_VERSION 31` but was still calling `filler()` with the 2.x 4-arg signature.

```
../../../lib/fs/fuse.c:151:36: error: too few arguments to function call, expected 5, have 4
../../../lib/fs/fuse.c:156:37: error: too few arguments to function call, expected 5, have 4
../../../lib/fs/fuse.c:165:45: error: too few arguments to function call, expected 5, have 4
```

Pass `0` (no flags) at all three call sites in `reffs_fuse_readdir`.

FreeBSD unaffected — fuse.c is skipped by the Makefile.am `!HOST_FREEBSD` conditional from PR #2.