### PR TITLE
io: _Atomic heartbeat_period on both backends

### DIFF
--- a/lib/io/backend_kqueue.c
+++ b/lib/io/backend_kqueue.c
@@ -46,6 +46,7 @@
 #include <fcntl.h>
 #include <pthread.h>
 #include <signal.h>
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -884,7 +885,14 @@ static int kqueue_arm_heartbeat_timer(struct ring_context *rc,
 #define KQUEUE_CONN_CHECK_INTERVAL 10
 #define KQUEUE_CONN_TIMEOUT 60
 
-static uint32_t kqueue_heartbeat_period = KQUEUE_HEARTBEAT_INTERVAL_SEC;
+/*
+ * kqueue_heartbeat_period is read on the main loop thread
+ * (io_schedule_heartbeat below) and written by the probe1 RPC worker
+ * thread via io_heartbeat_period_set.  _Atomic with RELAXED ordering:
+ * the value is advisory (next timer arm picks it up), no
+ * happens-before needed.
+ */
+static _Atomic uint32_t kqueue_heartbeat_period = KQUEUE_HEARTBEAT_INTERVAL_SEC;
 static uint64_t kqueue_heartbeat_completions = 0;
 static time_t kqueue_last_listener_check = 0;
 static time_t kqueue_last_conn_check = 0;
@@ -900,15 +908,14 @@ int io_heartbeat_init(struct ring_context *rc)
 
 uint32_t io_heartbeat_period_get(void)
 {
-	return kqueue_heartbeat_period;
+	return atomic_load_explicit(&kqueue_heartbeat_period,
+				    memory_order_relaxed);
 }
 
 uint32_t io_heartbeat_period_set(uint32_t seconds)
 {
-	uint32_t old = kqueue_heartbeat_period;
-
-	kqueue_heartbeat_period = seconds;
-	return old;
+	return atomic_exchange_explicit(&kqueue_heartbeat_period, seconds,
+					memory_order_relaxed);
 }
 
 void io_heartbeat_update_completions(uint64_t count)
@@ -929,8 +936,10 @@ int io_schedule_heartbeat(struct ring_context *rc)
 		return -ENOMEM;
 	}
 
+	uint32_t period = atomic_load_explicit(&kqueue_heartbeat_period,
+					       memory_order_relaxed);
 	return kqueue_arm_heartbeat_timer(
-		rc, ic, (uint64_t)kqueue_heartbeat_period * 1000000000ULL);
+		rc, ic, (uint64_t)period * 1000000000ULL);
 }
 
 int io_handle_heartbeat(struct io_context *ic, int result,

--- a/lib/io/heartbeat.c
+++ b/lib/io/heartbeat.c
@@ -11,6 +11,7 @@
 #include <liburing.h>
 #include <linux/time_types.h>
 #include <pthread.h>
+#include <stdatomic.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -37,7 +38,16 @@
 #define CONNECTION_CHECK_INTERVAL 10
 #define STATS_LOG_INTERVAL 10
 
-static uint32_t io_heartbeat_period = HEARTBEAT_INTERVAL;
+/*
+ * io_heartbeat_period is read on the main loop thread
+ * (io_schedule_heartbeat at line 122) and written by the probe1 RPC
+ * worker thread (probe1_op_heartbeat via io_heartbeat_period_set).
+ * Plain uint32_t load/store tears on architectures where the value
+ * straddles a cache line; use _Atomic with RELAXED ordering (no
+ * happens-before requirements -- the value is advisory, next timer
+ * arm picks it up).
+ */
+static _Atomic uint32_t io_heartbeat_period = HEARTBEAT_INTERVAL;
 
 // Structure to track when different checks were last performed
 struct heartbeat_state {
@@ -76,14 +86,14 @@ int io_heartbeat_init(struct ring_context *rc)
 
 uint32_t io_heartbeat_period_get(void)
 {
-	return io_heartbeat_period;
+	return atomic_load_explicit(&io_heartbeat_period,
+				    memory_order_relaxed);
 }
 
 uint32_t io_heartbeat_period_set(uint32_t seconds)
 {
-	uint32_t hb = io_heartbeat_period;
-	io_heartbeat_period = seconds;
-	return hb;
+	return atomic_exchange_explicit(&io_heartbeat_period, seconds,
+					memory_order_relaxed);
 }
 
 // Schedule a heartbeat operation using io_uring timeout
@@ -119,8 +129,10 @@ int io_schedule_heartbeat(struct ring_context *rc)
 		return -ENOSPC;
 	}
 
-	// Set up the timeout
-	ts->tv_sec = io_heartbeat_period;
+	// Set up the timeout (snapshot period once to avoid dual load)
+	uint32_t period = atomic_load_explicit(&io_heartbeat_period,
+					       memory_order_relaxed);
+	ts->tv_sec = period;
 	ts->tv_nsec = 0;
 
 	// Prepare the timeout operation
@@ -128,7 +140,7 @@ int io_schedule_heartbeat(struct ring_context *rc)
 			      0);
 	io_uring_sqe_set_data(sqe, ic);
 
-	TRACE("Scheduled next heartbeat in %u seconds", io_heartbeat_period);
+	TRACE("Scheduled next heartbeat in %u seconds", period);
 
 	// Submit the operation
 	ret = io_uring_submit(&rc->rc_ring);


### PR DESCRIPTION
Flagged by code review of PR #9 (kqueue heartbeat) as a pre-existing pattern on the liburing side too.

`io_heartbeat_period` (lib/io/heartbeat.c, liburing) and `kqueue_heartbeat_period` (lib/io/backend_kqueue.c, kqueue) are read on the main loop thread (from `io_schedule_heartbeat` when arming the next timer) and written by the probe1 RPC worker thread (from `probe1_op_heartbeat` via `io_heartbeat_period_set`).  Plain `uint32_t` load/store tears on architectures where the value straddles a cache line and is a C abstract-machine data race regardless.

Wrap both in `_Atomic` with `memory_order_relaxed`: the value is advisory (the next timer arm snapshots it; no happens-before relationship is required) and RELAXED suffices for tearing-free atomic reads on every arch the project supports.

## Changes

- `io_heartbeat_period_get` / `_set` converted to `atomic_load_explicit` / `atomic_exchange_explicit`
- Direct reads inside `io_schedule_heartbeat` snapshot once via `atomic_load`
- Comment documenting why RELAXED is the correct ordering
- `#include <stdatomic.h>` added to both files

## Test plan

- [x] Linux build (dreamer) clean
- [x] FreeBSD build (witchie) clean
- No functional change under normal conditions -- existing tests unaffected.