### PR TITLE
io/conn_info: io_conn_check_timeouts -- unlock before close, fix buffer_state leak

### DIFF
--- a/lib/io/conn_info.c
+++ b/lib/io/conn_info.c
@@ -716,7 +716,35 @@ void io_conn_dump_all(void)
 int io_conn_check_timeouts(time_t timeout_seconds)
 {
 	time_t now = time(NULL);
-	int closed = 0;
+	/*
+	 * Collect timed-out fds under conn_mutex, then release and close
+	 * each via io_socket_close() outside the mutex.  Two reasons:
+	 *
+	 *  1. close(2) under conn_mutex can block indefinitely under
+	 *     memory pressure or in the middle of kernel socket teardown;
+	 *     every other conn_info lookup in the process stalls while we
+	 *     wait.  Release the mutex first.
+	 *
+	 *  2. The original code used raw close(fd) + manual ci_state flip,
+	 *     which left conn_buffers[fd % MAX_CONNECTIONS] populated --
+	 *     a buffer_state leak.  io_socket_close() calls
+	 *     io_client_fd_unregister() which frees the buffer_state
+	 *     properly.
+	 *
+	 * Race note: between the scan and the close, another thread
+	 * could accept a new connection whose fd hashes to the same
+	 * conn_info slot.  For timed-out-idle connections this is
+	 * vanishingly unlikely (no completions fire on a truly idle fd),
+	 * and the worst case is closing a newly-accepted client which
+	 * will reconnect.  If this race ever materializes under real
+	 * load, the fix is a per-slot CLOSING state to block reuse; for
+	 * now the simplicity is worth it.
+	 *
+	 * Stack array sized at MAX_CONNECTIONS is fine: ~4 KB on the
+	 * heartbeat thread, which does not recurse.
+	 */
+	int to_close[MAX_CONNECTIONS];
+	int n_to_close = 0;
 
 	pthread_mutex_lock(&conn_mutex);
 
@@ -728,23 +756,17 @@ int io_conn_check_timeouts(time_t timeout_seconds)
 				LOG("Connection fd=%d timed out (%ld seconds inactive)",
 				    connections[i]->ci_fd,
 				    now - connections[i]->ci_last_activity);
-
-				close(connections[i]->ci_fd);
-
-				connections[i]->ci_state = CONN_UNUSED;
-				connections[i]->ci_fd = -1;
-				connections[i]->ci_read_count = 0;
-				connections[i]->ci_write_count = 0;
-				connections[i]->ci_accept_count = 0;
-				connections[i]->ci_connect_count = 0;
-
-				closed++;
+				to_close[n_to_close++] = connections[i]->ci_fd;
 			}
 		}
 	}
 
 	pthread_mutex_unlock(&conn_mutex);
-	return closed;
+
+	for (int i = 0; i < n_to_close; i++)
+		io_socket_close(to_close[i], ETIMEDOUT);
+
+	return n_to_close;
 }
 
 /*


### PR DESCRIPTION
Two pre-existing issues flagged by the code review of PR #9 (kqueue heartbeat):

1. **close(2) under conn_mutex** — socket close can block under memory pressure; every other conn_info lookup stalls while the heartbeat thread waits in close.
2. **buffer_state leak** — manual ci_state reset replaces raw close but doesn't call io_client_fd_unregister, leaving conn_buffers[fd % MAX_CONNECTIONS] populated.  The next accept whose fd hashes to the same slot hits the alias bail-out in io_buffer_state_create and silently drops the new connection.

Pre-existing since PR #4 (conn_info extraction) but now reachable via the kqueue heartbeat watchdog (PR #9) sweeping at every 10s tick.

## Fix

- Collect timed-out fds into a local array under conn_mutex (~4 KB, fine on heartbeat thread stack).
- Release mutex.
- Call `io_socket_close(fd, ETIMEDOUT)` on each.  io_socket_close handles the full teardown chain (io_conn_set_error → io_conn_unregister → io_client_fd_unregister → close(2)).

Race note documented in the code: between scan and close, another thread could accept a new fd hashing to the same conn_info slot.  For truly idle timed-out connections this is vanishingly unlikely (no completions fire on an idle fd) and the worst case is closing a newly-accepted client that reconnects.  If this materializes under real load, the fix is a per-slot CLOSING state to block reuse.

## Test plan

- [x] `make` clean on Linux (dreamer), `make check` passes
- [x] `gmake` clean on FreeBSD (witchie)
- Affects both backends via shared `conn_info.c`.  No new test added -- the code path was latent and only runs under production conditions (60s+ idle connection).