### PR TITLE
reffsd: FreeBSD startup probe for POSIX AIO limits

### DIFF
--- a/src/reffsd.c
+++ b/src/reffsd.c
@@ -10,8 +10,12 @@
 #include <getopt.h>
 #include <limits.h>
 #include <sys/stat.h>
+#ifdef __FreeBSD__
+#include <sys/sysctl.h>
+#endif
 #include <netinet/in.h>
 #include <rpc/pmap_clnt.h>
+#include <errno.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -277,6 +281,58 @@ int main(int argc, char *argv[])
 		LOG("reffsd %s (git %s) starting -- role=%s port=%d",
 		    PACKAGE_VERSION, REFFS_GIT_VERSION, role, cfg.port);
 	}
+
+#ifdef __FreeBSD__
+	/*
+	 * FreeBSD POSIX AIO limits are configurable via sysctl.  The
+	 * kqueue backend uses aio_read / aio_write for file I/O; under
+	 * concurrent NFS load with many inflight ops the defaults can
+	 * be hit silently, with aio_* returning EAGAIN until in-flight
+	 * ops complete.
+	 *
+	 * FreeBSD 15 ships two relevant limits:
+	 *
+	 *   vfs.aio.max_aio_per_proc    per-process concurrent AIO ops
+	 *   vfs.aio.max_aio_queue       system-wide queued AIO ops
+	 *
+	 * Defaults on FreeBSD 15 RELEASE are 32 and 1024 respectively --
+	 * far below what a concurrent NFS workload wants.  Warn at
+	 * startup so operators can raise before hitting the ceiling.
+	 *
+	 * Older sysctl names (kern.maxaio, kern.maxaiopp) are not
+	 * present on FreeBSD 15 and are not probed.
+	 */
+	{
+		const struct {
+			const char *name;
+			unsigned int recommended;
+		} probes[] = {
+			{ "vfs.aio.max_aio_per_proc", 256 },
+			{ "vfs.aio.max_aio_queue", 4096 },
+		};
+		for (size_t i = 0; i < sizeof(probes) / sizeof(probes[0]); i++) {
+			unsigned int value = 0;
+			size_t len = sizeof(value);
+			if (sysctlbyname(probes[i].name, &value, &len, NULL, 0) !=
+			    0) {
+				TRACE("FreeBSD %s not probeable: %s",
+				      probes[i].name, strerror(errno));
+				continue;
+			}
+			if (value < probes[i].recommended) {
+				LOG("FreeBSD %s=%u is below recommended %u for "
+				    "high-load NFS; raise via `sysctl -w %s=%u` "
+				    "(or add to /etc/sysctl.conf for persistence) if you "
+				    "see EAGAIN storms under concurrent file I/O",
+				    probes[i].name, value, probes[i].recommended,
+				    probes[i].name, probes[i].recommended);
+			} else {
+				TRACE("FreeBSD %s=%u (>= %u)", probes[i].name, value,
+				      probes[i].recommended);
+			}
+		}
+	}
+#endif
 
 	/*
 	 * If the config specifies trace_categories, it is authoritative:


### PR DESCRIPTION
Addresses plan Open Question 1 / W-5 from the port plan.  Under concurrent NFS load the kqueue backend's `aio_read` / `aio_write` can hit FreeBSD's default AIO ceilings silently (EAGAIN storms), producing throughput degradation that's hard to attribute from the outside.

## Changes

Probe two sysctls at startup on FreeBSD:

| sysctl | witchie default | recommended |
|---|---|---|
| `vfs.aio.max_aio_per_proc` | 32 | 256 |
| `vfs.aio.max_aio_queue` | 1024 | 4096 |

Log a WARN with the specific `sysctl -w` command if either is below the recommended value.  Silent TRACE pass if adequate; TRACE of probe failure if sysctlbyname itself fails.

Verified on witchie (FreeBSD 15.0-RELEASE-p5):

```
FreeBSD vfs.aio.max_aio_per_proc=32 is below recommended 256 for high-load NFS;
raise via `sysctl -w vfs.aio.max_aio_per_proc=256` (or add to /etc/sysctl.conf
for persistence) if you see EAGAIN storms under concurrent file I/O
FreeBSD vfs.aio.max_aio_queue=1024 is below recommended 4096 for high-load NFS;
raise via `sysctl -w vfs.aio.max_aio_queue=4096` ...
```

Note: plan proposed `kern.maxaio` but that sysctl does not exist on FreeBSD 15 (dropped in favor of the `vfs.aio.*` namespace).  The implementation uses the real names.

Linux unaffected — guarded with `#ifdef __FreeBSD__`.

The `[iouring]` → `[io_backend]` TOML section rename from plan Open Question 3 is deferred to a separate PR — it cross-cuts config parsing, examples, and tests and warrants its own review cycle.

## Test plan

- [x] Linux (dreamer) builds clean
- [x] FreeBSD (witchie) builds clean; reffsd startup emits both expected warnings
- Warnings are advisory; server runs either way