### PR TITLE
configure,darwin: add HOST_DARWIN host_os probe (macOS backend commit 1/10)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,13 +33,13 @@ AC_PROG_CC
 AC_USE_SYSTEM_EXTENSIONS
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 
-# FreeBSD installs headers and libraries under /usr/local by default
-# and the base toolchain does not search there unless told to.  Add
-# the standard pkg path so subsequent AC_CHECK_HEADER / AC_CHECK_LIB
-# probes can find ports-installed dependencies (libuuid,
-# HdrHistogram_c, etc.).
+# Per-host adjustments for BSDs and Darwin (macOS).  FreeBSD installs
+# ports under /usr/local; Darwin installs Homebrew under
+# /opt/homebrew (Apple Silicon) or /usr/local (Intel).  Neither is on
+# the base compiler's default search path.
 AC_CANONICAL_HOST
 host_is_freebsd=no
+host_is_darwin=no
 AS_CASE([$host_os],
     [freebsd*|dragonfly*], [
         CPPFLAGS="-I/usr/local/include $CPPFLAGS"
@@ -64,8 +64,40 @@ AS_CASE([$host_os],
         # globally so every binary gets the symbols.
         LIBS="-lexecinfo $LIBS"
         host_is_freebsd=yes
+    ],
+    [darwin*], [
+        # Homebrew paths.  Apple Silicon defaults to /opt/homebrew;
+        # Intel to /usr/local.  Probe at configure time so a user on
+        # an Intel Mac without /opt/homebrew does not get a broken
+        # -I/opt/homebrew flag (and vice versa).
+        AS_IF([test -d /opt/homebrew/include],
+              [CPPFLAGS="-I/opt/homebrew/include $CPPFLAGS"])
+        AS_IF([test -d /opt/homebrew/lib],
+              [LDFLAGS="-L/opt/homebrew/lib $LDFLAGS"])
+        AS_IF([test -d /usr/local/include],
+              [CPPFLAGS="-I/usr/local/include $CPPFLAGS"])
+        AS_IF([test -d /usr/local/lib],
+              [LDFLAGS="-L/usr/local/lib $LDFLAGS"])
+        # Same EREMOTEIO/ENODATA story as FreeBSD: Darwin errno.h
+        # has neither.  Pick reffs-internal sentinel values distinct
+        # from every POSIX/Darwin errno.  Darwin ELAST is 106
+        # (EQFULL), so 198/199 are safely above.  Must match the
+        # fallback in lib/include/reffs/log.h.
+        CPPFLAGS="-DEREMOTEIO=198 $CPPFLAGS"
+        CPPFLAGS="-DENODATA=199   $CPPFLAGS"
+        host_is_darwin=yes
     ])
 AM_CONDITIONAL([HOST_FREEBSD], [test "x$host_is_freebsd" = "xyes"])
+AM_CONDITIONAL([HOST_DARWIN],  [test "x$host_is_darwin"  = "xyes"])
+
+# NOTE to macOS users building reffs at this commit: the
+# IO_BACKEND_KQUEUE AM_CONDITIONAL further down this file does NOT
+# yet gate on host_is_freebsd, so it will misdetect macOS as FreeBSD
+# (kqueue + aio probes all succeed on Darwin).  The resulting build
+# compiles and links but hits Darwin's POSIX aio pathology at
+# runtime.  Commit 3 of the macOS-backend series fixes this gate and
+# introduces IO_BACKEND_DARWIN.  Do not attempt to run reffsd on
+# macOS until commit 3 lands.
 
 AC_MSG_CHECKING([for C11 support])
 dnl Strip out the freaking -O2 by default!

--- a/lib/fs/Makefile.am
+++ b/lib/fs/Makefile.am
@@ -35,9 +35,13 @@ libreffs_fs_la_SOURCES = \
 # fuse.c wraps libfuse callbacks for a userspace mount utility and
 # is only needed on Linux at the moment.  Its callback signatures
 # target libfuse2-era APIs (4-arg readdir) while FreeBSD ships only
-# libfuse3 (5-arg).  Port separately; for now, skip on FreeBSD.
+# libfuse3 (5-arg).  macOS's macFUSE has its own Apple-specific
+# extensions and a separate porting story.  Port separately; for
+# now, skip on FreeBSD and Darwin.
 if !HOST_FREEBSD
+if !HOST_DARWIN
 libreffs_fs_la_SOURCES += fuse.c
+endif
 endif
 
 libreffs_fs_la_LIBADD = $(top_builddir)/lib/backends/libbackends.la

--- a/lib/include/reffs/log.h
+++ b/lib/include/reffs/log.h
@@ -39,6 +39,8 @@
 #include <sys/syscall.h>
 #elif defined(__FreeBSD__)
 #include <pthread_np.h>
+#elif defined(__APPLE__)
+#include <pthread.h>
 #endif
 
 #ifdef __clang__
@@ -48,9 +50,11 @@
 
 /*
  * Portable kernel thread id accessor.  Linux: syscall(SYS_gettid).
- * FreeBSD: pthread_getthreadid_np(), a non-portable extension.  Both
- * return a small integer that uniquely identifies the kernel thread
- * within the process; suitable for log/trace prefixes.
+ * FreeBSD: pthread_getthreadid_np(), a non-portable extension.
+ * macOS: pthread_threadid_np() returns a 64-bit thread id (since
+ * 10.6); truncate to pid_t for consistency with the other paths.
+ * All three return a small integer unique within the process;
+ * suitable for log/trace prefixes.
  */
 static inline pid_t reffs_gettid(void)
 {
@@ -58,6 +62,10 @@ static inline pid_t reffs_gettid(void)
 	return (pid_t)syscall(SYS_gettid);
 #elif defined(__FreeBSD__)
 	return (pid_t)pthread_getthreadid_np();
+#elif defined(__APPLE__)
+	uint64_t tid = 0;
+	pthread_threadid_np(NULL, &tid);
+	return (pid_t)tid;
 #else
 	return (pid_t)getpid();
 #endif


### PR DESCRIPTION
First commit in the 10-commit macOS I/O backend series (see `~/.claude/plans/macos-backend.md` and its addendum for the full plan).

## What this commit does

- `configure.ac`: adds an `AS_CASE darwin*` branch alongside the existing `freebsd*`. Homebrew header/library paths probed at configure time (`/opt/homebrew` on Apple Silicon AND `/usr/local` on Intel, added only if the dir exists). Same `EREMOTEIO=198` / `ENODATA=199` sentinel story as FreeBSD (Darwin errno.h has neither; ELAST=106 so 198/199 are above). New `AM_CONDITIONAL([HOST_DARWIN])`.
- `lib/fs/Makefile.am`: wraps the existing `if !HOST_FREEBSD` around `fuse.c` with an additional `if !HOST_DARWIN`. macFUSE has its own port story; defer.
- `lib/include/reffs/log.h`: `reffs_gettid()` gets an `__APPLE__` branch using `pthread_threadid_np` (macOS 10.6+).

## What this commit does NOT do

The `IO_BACKEND_KQUEUE` conditional further down in `configure.ac` is NOT modified. On macOS all kqueue+aio probes pass, so the condition remains true on Darwin and the existing FreeBSD backend will compile and link. This is the BLOCKER (B-1) that commit 3 fixes by adding a positive `host_is_freebsd=yes` check.

**Do not attempt to run reffsd on macOS until commit 3 lands.** A NOTE comment in `configure.ac` spells this out.

## Test plan

- [x] Linux (dreamer) `./configure && make -j4`: clean, no new warnings
- [x] FreeBSD (witchie) `./configure && gmake -j4`: clean, no new warnings
- [ ] macOS: deferred to commit 3 (see above)

## Plan addendum context

Pre-code plan review found 1 BLOCKER (B-1, addressed by commit 3) and 4 WARNINGs:
- W-5: three-bucket extraction (commit 4 introduces `kqueue_common.c`, `kqueue_common.h`, `kqueue_socket.c`)
- W-6: TSAN annotations cover `dp_job` not just `ic` (commit 6)
- W-7: `backend_darwin.c` owns its own kqueue fd (commit 5)
- W-8: kTLS macro runtime-benign on macOS (documented, no code change)

Plus 5 NOTEs applied in later commits.