### PR TITLE
nfs4: callback and TEST_STATEID interop fixes for the Linux client

### DIFF
--- a/lib/fs/stateid.c
+++ b/lib/fs/stateid.c
@@ -38,6 +38,16 @@ static int stateid_match(struct cds_lfht_node *ht_node, const void *vkey)
 	return *key == stid->s_id;
 }
 
+/* The client table hashes s_client_node; the container offset differs. */
+static int stateid_match_client(struct cds_lfht_node *ht_node, const void *vkey)
+{
+	struct stateid *stid =
+		caa_container_of(ht_node, struct stateid, s_client_node);
+	const uint32_t *key = vkey;
+
+	return *key == stid->s_id;
+}
+
 /* ------------------------------------------------------------------ */
 /* Internal assign                                                     */
 
@@ -139,7 +149,7 @@ int stateid_assign(struct stateid *stid, struct inode *inode,
 		rcu_read_lock();
 		stid->s_state |= STID_IS_CLIENT_HASHED;
 		node = cds_lfht_add_unique(client->c_stateids, hash,
-					   stateid_match, &stid->s_id,
+					   stateid_match_client, &stid->s_id,
 					   &stid->s_client_node);
 		rcu_read_unlock();
 
@@ -253,5 +263,30 @@ struct stateid *stateid_find(struct inode *inode, uint32_t id)
 
 	trace_fs_stateid(stid, __func__, __LINE__);
 
+	return stid;
+}
+
+struct stateid *stateid_find_client(struct client *client, uint32_t id)
+{
+	struct stateid *stid = NULL;
+	struct stateid *tmp;
+	struct cds_lfht_iter iter;
+	struct cds_lfht_node *node;
+	unsigned long hash = XXH3_64bits(&id, sizeof(id));
+
+	if (!client || !client->c_stateids)
+		return NULL;
+
+	rcu_read_lock();
+	cds_lfht_lookup(client->c_stateids, hash, stateid_match_client, &id,
+			&iter);
+	node = cds_lfht_iter_get_node(&iter);
+	if (node) {
+		tmp = caa_container_of(node, struct stateid, s_client_node);
+		stid = stateid_get(tmp);
+	}
+	rcu_read_unlock();
+
+	trace_fs_stateid(stid, __func__, __LINE__);
 	return stid;
 }

--- a/lib/include/reffs/stateid.h
+++ b/lib/include/reffs/stateid.h
@@ -61,6 +61,13 @@ int stateid_assign(struct stateid *stid, struct inode *inode,
  */
 struct stateid *stateid_find(struct inode *inode, uint32_t id);
 
+/*
+ * stateid_find_client - look up by (client, wire id), independent of
+ * any filehandle.  Returns a ref-bumped pointer or NULL.  Caller must
+ * stateid_put() it.
+ */
+struct stateid *stateid_find_client(struct client *client, uint32_t id);
+
 /* Bump / drop ref */
 struct stateid *stateid_get(struct stateid *stid);
 void stateid_put(struct stateid *stid);

--- a/lib/nfs4/include/nfs4/session.h
+++ b/lib/nfs4/include/nfs4/session.h
@@ -93,6 +93,16 @@ struct nfs4_session {
 	int ns_cb_fd; /* fd of the connection (fore-channel reused) */
 	sequenceid4 ns_cb_seqid; /* next CB_SEQUENCE sequenceid to send */
 	pthread_mutex_t ns_cb_mutex; /* serializes CB sends on this session */
+	/*
+	 * Backchannel credential (RFC 8881 sec 18.36: the server MUST
+	 * use one of the client's csa_sec_parms on the backchannel).
+	 * The XDR-encoded AUTH_SYS cred body from CREATE_SESSION, sent
+	 * verbatim in every CB call's RPC header; len 0 -> AUTH_NONE
+	 * (the Linux client rejects AUTH_NONE for everything but
+	 * CB_NULL with AUTH_ERROR/badcred).
+	 */
+	uint8_t ns_cb_cred[400]; /* MAX_AUTH_BYTES (RFC 5531) */
+	uint32_t ns_cb_cred_len;
 
 	struct rcu_head ns_rcu;
 	struct urcu_ref ns_ref;

--- a/lib/nfs4/include/nfs4/session.h
+++ b/lib/nfs4/include/nfs4/session.h
@@ -89,6 +89,10 @@ struct nfs4_session {
 	struct nfs4_slot *ns_slots; /* calloc'd [0..ns_slot_count-1] */
 
 	/* Back channel */
+	uint32_t ns_minorversion; /* minorversion of the CREATE_SESSION
+				   * compound; CB_COMPOUNDs must carry the
+				   * same one (the Linux client matches
+				   * callbacks to clients by it) */
 	uint32_t ns_cb_program; /* csa_cb_program from CREATE_SESSION */
 	int ns_cb_fd; /* fd of the connection (fore-channel reused) */
 	sequenceid4 ns_cb_seqid; /* next CB_SEQUENCE sequenceid to send */

--- a/lib/nfs4/server/cb.c
+++ b/lib/nfs4/server/cb.c
@@ -262,7 +262,7 @@ int nfs4_cb_recall(struct nfs4_session *session, const stateid4 *stateid,
 
 	args.tag.utf8string_val = (char *)"CB_RECALL";
 	args.tag.utf8string_len = sizeof("CB_RECALL") - 1;
-	args.minorversion = 1;
+	args.minorversion = session->ns_minorversion;
 	args.callback_ident = session->ns_cb_program;
 	args.argarray.argarray_len = 2;
 	args.argarray.argarray_val = ops;
@@ -326,7 +326,7 @@ int nfs4_cb_layoutrecall_fnf(struct nfs4_session *session,
 
 	args.tag.utf8string_val = (char *)"CB_LAYOUTRECALL";
 	args.tag.utf8string_len = sizeof("CB_LAYOUTRECALL") - 1;
-	args.minorversion = 1;
+	args.minorversion = session->ns_minorversion;
 	args.callback_ident = session->ns_cb_program;
 	args.argarray.argarray_len = 2;
 	args.argarray.argarray_val = ops;
@@ -380,7 +380,7 @@ int nfs4_cb_getattr_send(struct nfs4_session *session, const nfs_fh4 *fh,
 
 	args.tag.utf8string_val = (char *)"CB_GETATTR";
 	args.tag.utf8string_len = sizeof("CB_GETATTR") - 1;
-	args.minorversion = 1;
+	args.minorversion = session->ns_minorversion;
 	args.callback_ident = session->ns_cb_program;
 	args.argarray.argarray_len = 2;
 	args.argarray.argarray_val = ops;
@@ -455,7 +455,7 @@ int nfs4_cb_layoutrecall_send(struct nfs4_session *session,
 
 	args.tag.utf8string_val = (char *)"CB_LAYOUTRECALL";
 	args.tag.utf8string_len = sizeof("CB_LAYOUTRECALL") - 1;
-	args.minorversion = 1;
+	args.minorversion = session->ns_minorversion;
 	args.callback_ident = session->ns_cb_program;
 	args.argarray.argarray_len = 2;
 	args.argarray.argarray_val = ops;

--- a/lib/nfs4/server/cb.c
+++ b/lib/nfs4/server/cb.c
@@ -80,11 +80,24 @@ static int cb_build_and_alloc(struct nfs4_session *session,
 	uint32_t *p;
 	uint32_t body_len;
 	uint32_t xid;
+	uint32_t cred_len;
+	uint32_t cred_pad;
 	struct rpc_trans *cb_rt;
 	XDR xdrs = { 0 };
 
+	/*
+	 * RFC 8881 sec 18.36: backchannel calls carry one of the
+	 * client's csa_sec_parms credentials.  Use the AUTH_SYS body
+	 * captured at CREATE_SESSION; AUTH_NONE only when the client
+	 * offered no AUTH_SYS parm (the Linux client rejects AUTH_NONE
+	 * for real callback procedures with AUTH_ERROR/badcred).
+	 */
+	cred_len = session->ns_cb_cred_len;
+	cred_pad = (cred_len + 3u) & ~3u;
+
 	xdr_size = xdr_sizeof((xdrproc_t)xdr_CB_COMPOUND4args, args);
-	buf_len = RPC_CALL_HEADER_WORDS * sizeof(uint32_t) + xdr_size;
+	buf_len =
+		RPC_CALL_HEADER_WORDS * sizeof(uint32_t) + cred_pad + xdr_size;
 
 	buf = calloc(buf_len, 1);
 	if (!buf)
@@ -101,14 +114,16 @@ static int cb_build_and_alloc(struct nfs4_session *session,
 	*p++ = htonl(NFS4_CALLBACK);
 	*p++ = htonl(NFS_CB);
 	*p++ = htonl(CB_COMPOUND_PROC);
-	*p++ = htonl(AUTH_NONE);
-	*p++ = htonl(0); /* cred length */
+	*p++ = htonl(cred_len ? AUTH_SYS : AUTH_NONE);
+	*p++ = htonl(cred_len);
+	if (cred_len) {
+		memcpy(p, session->ns_cb_cred, cred_len);
+		p += cred_pad / sizeof(uint32_t);
+	}
 	*p++ = htonl(AUTH_NONE);
 	*p++ = htonl(0); /* verf length */
 
-	xdrmem_create(&xdrs, (char *)p,
-		      buf_len - RPC_CALL_HEADER_WORDS * sizeof(uint32_t),
-		      XDR_ENCODE);
+	xdrmem_create(&xdrs, (char *)p, xdr_size, XDR_ENCODE);
 	if (!xdr_CB_COMPOUND4args(&xdrs, args)) {
 		xdr_destroy(&xdrs);
 		free(buf);

--- a/lib/nfs4/server/lock.c
+++ b/lib/nfs4/server/lock.c
@@ -572,12 +572,20 @@ uint32_t nfs4_op_test_stateid(struct compound *compound)
 		}
 
 		/*
-		 * Look up the stateid in the inode's per-inode hash table.
-		 * A stateid present in the table is valid; one absent has
-		 * been freed, was never issued, or belongs to a different
-		 * inode (RFC 8881 S18.47.3).
+		 * Look up the stateid in the calling client's stateid
+		 * table.  TEST_STATEID has no current-filehandle
+		 * dependency (RFC 8881 S18.48.3: stateids are bound to
+		 * the client, and the Linux client sends the compound
+		 * with no PUTFH), so a per-inode lookup would wrongly
+		 * fail valid stateids.  A stateid absent from the client
+		 * table has been freed, was never issued, or belongs to
+		 * another client.
 		 */
-		struct stateid *found = stateid_find(compound->c_inode, id);
+		struct stateid *found = stateid_find_client(
+			compound->c_nfs4_client ?
+				nfs4_client_to_client(compound->c_nfs4_client) :
+				NULL,
+			id);
 
 		if (!found) {
 			res->TEST_STATEID4res_u.tsr_resok4.tsr_status_codes

--- a/lib/nfs4/server/session.c
+++ b/lib/nfs4/server/session.c
@@ -673,6 +673,7 @@ uint32_t nfs4_op_create_session(struct compound *compound)
 	 * having the program number already on hand.
 	 */
 	ns->ns_cb_program = args->csa_cb_program;
+	ns->ns_minorversion = compound->c_args->minorversion;
 	ns->ns_cb_seqid = 0;
 	if (args->csa_flags & CREATE_SESSION4_FLAG_CONN_BACK_CHAN)
 		ns->ns_cb_fd = compound->c_rt->rt_fd;

--- a/lib/nfs4/server/session.c
+++ b/lib/nfs4/server/session.c
@@ -677,6 +677,29 @@ uint32_t nfs4_op_create_session(struct compound *compound)
 	if (args->csa_flags & CREATE_SESSION4_FLAG_CONN_BACK_CHAN)
 		ns->ns_cb_fd = compound->c_rt->rt_fd;
 
+	/*
+	 * Capture the client's AUTH_SYS backchannel credential (RFC
+	 * 8881 sec 18.36: the server MUST use one of csa_sec_parms on
+	 * its CB calls).  First AUTH_SYS entry wins; without one, CB
+	 * calls fall back to AUTH_NONE, which the Linux client rejects
+	 * with AUTH_ERROR/badcred for everything but CB_NULL.
+	 */
+	for (uint32_t i = 0; i < args->csa_sec_parms.csa_sec_parms_len; i++) {
+		callback_sec_parms4 *sp =
+			&args->csa_sec_parms.csa_sec_parms_val[i];
+		XDR cx;
+
+		if (sp->cb_secflavor != AUTH_SYS)
+			continue;
+		xdrmem_create(&cx, (char *)ns->ns_cb_cred,
+			      sizeof(ns->ns_cb_cred), XDR_ENCODE);
+		if (xdr_authunix_parms(
+			    &cx, &sp->callback_sec_parms4_u.cbsp_sys_cred))
+			ns->ns_cb_cred_len = (uint32_t)xdr_getpos(&cx);
+		xdr_destroy(&cx);
+		break;
+	}
+
 	memcpy(resok->csr_sessionid, ns->ns_sessionid, sizeof(sessionid4));
 	resok->csr_sequence = args->csa_sequence;
 	/*


### PR DESCRIPTION
Three fixes found while wire-testing reffs callbacks against a Linux
NFSv4.2 client (7.1).  Before these, no reffs callback was ever accepted
by a Linux client, and the client's stateid-recovery compounds failed:

1. **Callbacks went out with AUTH_NONE.**  Linux rejects everything but
   CB_NULL with `AUTH_ERROR/badcred`.  RFC 8881 §18.36 requires the
   server to use one of the client's `csa_sec_parms` on the back
   channel; capture the client's AUTH_SYS credential at CREATE_SESSION
   and replay it verbatim on every callback.

2. **Callbacks hardcoded minorversion 1.**  Linux matches callbacks to
   clients by address *and* minorversion, so a v4.2 session answered
   `NFS4ERR_BADSESSION` to a byte-identical session ID.  Record the
   CREATE_SESSION compound's minorversion and use it on all senders.

3. **TEST_STATEID looked up stateids per-inode.**  RFC 8881 §18.48
   operates on the client's stateid table with no filehandle in scope;
   the per-inode lookup returned `BAD_STATEID` for every FH-less
   compound (exactly what the Linux client sends during layout-stateid
   recovery).  Look up in the client table instead; this also fixes a
   latent wrong-container match in the client-table hash compare.

Tested: full suite 155 PASS under ASAN/UBSAN; wire-verified against a
Linux 7.1 client — CB_LAYOUTRECALL and CB_NOTIFY_DEVICEID are accepted
and replied NFS4_OK, and the client's TEST_STATEID-driven recovery
completes (previously impossible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fykvy9tvJtnBM3AV891us
