### PR TITLE
lib/ec/mojette: default GD inverse dispatcher + ec_bench harness fixes

### DIFF
--- a/lib/ec/linux-md-raid/neon.h
+++ b/lib/ec/linux-md-raid/neon.h
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include <stdint.h>
+
 void raid6_neon1_gen_syndrome_real(int disks, unsigned long bytes, void **ptrs);
 void raid6_neon1_xor_syndrome_real(int disks, int start, int stop,
 				    unsigned long bytes, void **ptrs);

--- a/lib/ec/mojette.c
+++ b/lib/ec/mojette.c
@@ -77,7 +77,9 @@
 /* ------------------------------------------------------------------ */
 
 static _Atomic bool moj_scalar_only;
-static _Atomic bool moj_gd_enabled;
+/* Geometry-driven inverse dispatcher defaults on; measurably faster than
+ * peel at the sizes ec_bench exercises.  moj_force_gd(false) pins peel. */
+static _Atomic bool moj_gd_enabled = true;
 
 void moj_force_scalar(bool force)
 {

--- a/tools/ec_bench.c
+++ b/tools/ec_bench.c
@@ -119,22 +119,28 @@ static uint64_t time_encode(struct ec_encoding *c, uint8_t **data,
 /* Time decode with shard[erase_idx] dropped.  All shards are set up
  * fresh each iter (memcpy from snapshot) so consecutive iters do not
  * observe already-recovered state. */
+static size_t bench_shard_bytes(struct ec_encoding *c, int shard_idx,
+				size_t data_shard_len);
+
 static uint64_t time_decode(struct ec_encoding *c, uint8_t **shards,
 			    uint8_t **snapshot, int k, int m, int erase_idx,
 			    size_t shard_len, int iters, int warmup)
 {
 	int n = k + m;
 	bool *present = calloc(n, sizeof(*present));
+	size_t *ssize = calloc(n, sizeof(*ssize));
 
-	for (int i = 0; i < n; i++)
+	for (int i = 0; i < n; i++) {
 		present[i] = true;
+		ssize[i] = bench_shard_bytes(c, i, shard_len);
+	}
 	present[erase_idx] = false;
 
 	/* Warmup */
 	for (int w = 0; w < warmup; w++) {
 		for (int i = 0; i < n; i++)
-			memcpy(shards[i], snapshot[i], shard_len);
-		memset(shards[erase_idx], 0, shard_len);
+			memcpy(shards[i], snapshot[i], ssize[i]);
+		memset(shards[erase_idx], 0, ssize[erase_idx]);
 		c->ec_decode(c, shards, present, shard_len);
 	}
 
@@ -142,8 +148,8 @@ static uint64_t time_decode(struct ec_encoding *c, uint8_t **shards,
 
 	for (int i = 0; i < iters; i++) {
 		for (int j = 0; j < n; j++)
-			memcpy(shards[j], snapshot[j], shard_len);
-		memset(shards[erase_idx], 0, shard_len);
+			memcpy(shards[j], snapshot[j], ssize[j]);
+		memset(shards[erase_idx], 0, ssize[erase_idx]);
 
 		uint64_t t0 = now_ns();
 
@@ -153,6 +159,7 @@ static uint64_t time_decode(struct ec_encoding *c, uint8_t **shards,
 		if (elapsed < best)
 			best = elapsed;
 	}
+	free(ssize);
 	free(present);
 	return best;
 }
@@ -223,10 +230,13 @@ static void bench_one(const char *label, struct ec_encoding *c, int k, int m,
 	uint64_t dec_ns = time_decode(c, shards, snapshot, k, m, 1, shard_len,
 				      iters, warmup);
 
+	int correct = memcmp(shards[1], snapshot[1], shard_len) == 0;
+
 	printf("%-14s k=%d m=%d size=%7zu  enc %6.1f MB/s (%6" PRIu64
-	       " ns)  dec %6.1f MB/s (%6" PRIu64 " ns)\n",
+	       " ns)  dec %6.1f MB/s (%6" PRIu64 " ns)%s\n",
 	       label, k, m, shard_len, mb_per_sec(k, shard_len, enc_ns), enc_ns,
-	       mb_per_sec(k, shard_len, dec_ns), dec_ns);
+	       mb_per_sec(k, shard_len, dec_ns), dec_ns,
+	       correct ? "" : "  CORRUPT");
 
 	for (int i = 0; i < k; i++) {
 		free(data[i]);

--- a/tools/ec_bench.c
+++ b/tools/ec_bench.c
@@ -94,17 +94,27 @@ static double mb_per_sec(int k, size_t shard_len, uint64_t elapsed_ns)
 	return (bytes / secs) / (1024.0 * 1024.0);
 }
 
-/* Time encode over `iters` runs.  Returns min ns per iter. */
-static uint64_t time_encode(struct ec_encoding *c, uint8_t **data,
-			    uint8_t **parity, size_t shard_len, int iters,
-			    int warmup)
+/* Time encode over `iters` runs.  Returns min ns per iter.
+ * Non-systematic encoders overwrite data[i] with projections in place,
+ * so subsequent encode calls would transform garbage.  Reset data[i]
+ * from `orig` before every call (including warmup) so every timed
+ * encode starts from the same authentic input. */
+static uint64_t time_encode(struct ec_encoding *c, int k, uint8_t **data,
+			    uint8_t **orig, uint8_t **parity, size_t shard_len,
+			    int iters, int warmup)
 {
-	for (int i = 0; i < warmup; i++)
+	for (int i = 0; i < warmup; i++) {
+		for (int j = 0; j < k; j++)
+			memcpy(data[j], orig[j], shard_len);
 		c->ec_encode(c, data, parity, shard_len);
+	}
 
 	uint64_t best = UINT64_MAX;
 
 	for (int i = 0; i < iters; i++) {
+		for (int j = 0; j < k; j++)
+			memcpy(data[j], orig[j], shard_len);
+
 		uint64_t t0 = now_ns();
 
 		c->ec_encode(c, data, parity, shard_len);
@@ -209,28 +219,38 @@ static void bench_one(const char *label, struct ec_encoding *c, int k, int m,
 
 	fill_shards(data, k, shard_len);
 
+	/* Preserve original data before encode.  Non-systematic encoders
+	 * overwrite data[i] with projections, so we need the untouched
+	 * originals both to reset data before each timed encode iter and
+	 * to check what decode recovered after the timed decode loop. */
+	uint8_t **orig = calloc(k, sizeof(*orig));
+
+	for (int i = 0; i < k; i++) {
+		orig[i] = aligned_alloc(64, shard_len);
+		memcpy(orig[i], data[i], shard_len);
+	}
+
 	uint64_t enc_ns =
-		time_encode(c, data, parity, shard_len, iters, warmup);
+		time_encode(c, k, data, orig, parity, shard_len, iters, warmup);
 
 	/* Snapshot the encoded shards so decode sees an authentic input.
-	 * Data shards are shard_len; parity shards use the encoder's
-	 * ec_shard_size (Mojette non-systematic can be larger). */
-	for (int i = 0; i < k; i++)
-		memcpy(snapshot[i], data[i], shard_len);
-	for (int i = 0; i < m; i++) {
-		size_t sz = c->ec_shard_size ?
-				    c->ec_shard_size(c, k + i, shard_len) :
-				    shard_len;
-
-		memcpy(snapshot[k + i], parity[i], sz);
-	}
+	 * Both data and parity use bench_shard_bytes so nonsys "data"
+	 * shards (which are projections at nbins*8, not shard_len) get
+	 * fully snapshotted. */
+	for (int i = 0; i < k + m; i++)
+		memcpy(snapshot[i], (i < k ? data[i] : parity[i - k]),
+		       bench_shard_bytes(c, i, shard_len));
 
 	/* Decode with one data shard missing (index 1 -- avoid 0 which
 	 * often triggers a fast-path in some encodings). */
 	uint64_t dec_ns = time_decode(c, shards, snapshot, k, m, 1, shard_len,
 				      iters, warmup);
 
-	int correct = memcmp(shards[1], snapshot[1], shard_len) == 0;
+	int correct = memcmp(shards[1], orig[1], shard_len) == 0;
+
+	for (int i = 0; i < k; i++)
+		free(orig[i]);
+	free(orig);
 
 	printf("%-14s k=%d m=%d size=%7zu  enc %6.1f MB/s (%6" PRIu64
 	       " ns)  dec %6.1f MB/s (%6" PRIu64 " ns)%s\n",


### PR DESCRIPTION
Slim slice, one substantive semantic change + three bench/build fixes surfaced
by chasing it.

## Summary

- **`lib/ec/mojette`**: default the geometry-driven inverse
  dispatcher on.  `moj_force_gd(false)` still pins peel for callers
  that want the older path.  This is a one-line initialization
  flip; the algorithmic work was PR #58's (paper-convention
  refactor).  Delivers a ~336x algorithmic uplift at the mana
  headline cell (peel 9.4 MB/s → GD 3164 MB/s at k=4 m=2 65 KiB
  under matched -O2 flags, both \`match=1\` verified).

- **`tools/ec_bench`** (two fixes): 
  1. \`time_decode\` per-shard memcpy from snapshot uses the
     encoder's actual shard size, not shard_len.  Mojette parity
     shards can exceed shard_len (nbins*8; direction (2,1) at k=4
     P=8192 needs 131 KiB, not 64 KiB).  The under-copy left the
     parity tail as garbage after iter 0, fast-failing peel_sparse
     at a false ~9.6 MB/s -- that's what Slice R.5 was actually
     measuring, not real decode work.
  2. \`time_encode\` resets \`data[]\` from a preserved \`orig[]\`
     before every encode call.  Non-systematic mojette encode
     overwrites \`data[i]\` in place with projections, so
     repeated encode-timing iterations were transforming
     projections-of-projections.  Verify now compares against
     \`orig\` (works for both sys and nonsys).
  Both fixes came with a memcmp correctness check on every cell.
  With both fixes, every mojette-sys AND mojette-nonsys cell
  passes \`match=1\`.

- **`lib/ec/linux-md-raid/neon.h`**: \`#include <stdint.h>\` so
  \`uint8_t\` in the raid6_neon function prototypes is defined
  without depending on translation-unit include order.  Some
  Fedora clang versions (dreamer) fail without this.

## Not included from the original slice family

The original R.4.1 branch also carried a rows-variant Mojette
inverse API (\`31d11cc3cb6a\`).  Bisect shows it's a small GD
regression (~10%, from 618 → 562 MB/s at matched flags) and
neutral on peel; no clear downstream consumer (Slice R.2-decode
NEON scoping shows the vectorization opportunity is at the
\`mp_bins\` writes, not row reads).  Dropped from the slim slice.

## Test plan

- [x] \`make -C build/lib/ec check\`: 10/10 PASS (matrix, mirror,
  mojette, mojette_encoding, rs, xor, snapraid, linux_md, isa_l, gf)
- [x] \`ec_bench --iters 20 --sizes 65536\`: every row prints
  numeric MB/s with no \`CORRUPT\` flag; mojette-sys k=4 m=2
  measures 3164 MB/s decode on mana
- [x] \`make style\`, \`make license\`: both clean
- [x] Local build with \`--enable-ubsan\` (matches nightly)

## Related

- Full slice + decision write-up:
  \`slice-R4-decode-scoping.md\` (reffs-docs)
- R.2-decode-NEON follow-up scoping:
  \`slice-R2-decode-scoping.md\` (reffs-docs)
- HS-internal deck update:
  \`ietf126-hs-summary.md\` commits \`83ccc82eee2c\` +
  \`181ec1734b12\`